### PR TITLE
RestfulApi增加了批量更新接口

### DIFF
--- a/AgileConfig.Server.Apisite/Controllers/api/ConfigController.cs
+++ b/AgileConfig.Server.Apisite/Controllers/api/ConfigController.cs
@@ -257,7 +257,38 @@ namespace AgileConfig.Server.Apisite.Controllers.api
                 obj.message
             });
         }
+        /// <summary>
+        /// 合并修改配置
+        /// </summary>
+        /// <param name="data">模型</param>
+        /// <param name="appId" >配置id</param>
+        /// <param name="env">环境</param>
+        /// <returns></returns>
+        [TypeFilter(typeof(AdmBasicAuthenticationAttribute))]
+        [TypeFilter(typeof(PremissionCheckByBasicAttribute), Arguments = new object[] { "Config.MergeUpdate", Functions.Config_MergeUpdate })]
+        [HttpPost("/api/Config/MergeUpdate")]
+        public async Task<IActionResult> MergeUpdate([FromBody] SaveJsonVM data, string appId, string env)
+        {
+            if (string.IsNullOrEmpty(appId))
+            {
+                throw new ArgumentNullException(nameof(appId));
+            }
 
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            if (string.IsNullOrEmpty(data.json))
+            {
+                throw new ArgumentNullException("data.json");
+            }
+            var result = await _configService.MergeUpdateJsonAsync(data.json, appId, env);
+            return Json(new
+            {
+                success = result
+            });
+        }
         /// <summary>
         /// 删除一个配置
         /// </summary>

--- a/AgileConfig.Server.IService/IConfigService.cs
+++ b/AgileConfig.Server.IService/IConfigService.cs
@@ -60,6 +60,14 @@ namespace AgileConfig.Server.IService
         Task<bool> UpdateAsync(Config config, string env);
 
         Task<bool> UpdateAsync(List<Config> configs, string env);
+        /// <summary>
+        /// 合并更新配置
+        /// </summary>
+        /// <param name="json"></param>
+        /// <param name="appId"></param>
+        /// <param name="env"></param>
+        /// <returns></returns>
+        Task<bool> MergeUpdateJsonAsync(string json, string appId, string env);
 
         /// <summary>
         /// 撤销编辑状态

--- a/AgileConfig.Server.IService/IPremissionService.cs
+++ b/AgileConfig.Server.IService/IPremissionService.cs
@@ -15,6 +15,7 @@ namespace AgileConfig.Server.IService
 
         public const string Config_Add = "CONFIG_ADD";
         public const string Config_Edit = "CONFIG_EDIT";
+        public const string Config_MergeUpdate = "CONFIG_MERGEUPDATE";
         public const string Config_Delete = "CONFIG_DELETE";
 
         public const string Config_Publish = "CONFIG_PUBLISH";

--- a/AgileConfig.Server.Service/PremissionService.cs
+++ b/AgileConfig.Server.Service/PremissionService.cs
@@ -25,6 +25,7 @@ namespace AgileConfig.Server.Service
             "GLOBAL_" + Functions.Config_Add,
             "GLOBAL_" + Functions.Config_Delete,
             "GLOBAL_" + Functions.Config_Edit,
+            "GLOBAL_" + Functions.Config_MergeUpdate,
             "GLOBAL_" + Functions.Config_Offline,
             "GLOBAL_" + Functions.Config_Publish,
 
@@ -56,6 +57,7 @@ namespace AgileConfig.Server.Service
             "APP_{0}_" + Functions.Config_Add,
             "APP_{0}_" + Functions.Config_Delete,
             "APP_{0}_" + Functions.Config_Edit,
+            "APP_{0}_" + Functions.Config_MergeUpdate,
             "APP_{0}_" + Functions.Config_Offline,
             "APP_{0}_" + Functions.Config_Publish,
         };
@@ -65,6 +67,7 @@ namespace AgileConfig.Server.Service
             "APP_{0}_" + Functions.Config_Add,
             "APP_{0}_" + Functions.Config_Delete,
             "APP_{0}_" + Functions.Config_Edit,
+            "APP_{0}_" + Functions.Config_MergeUpdate,
         };
 
         private static readonly List<string> Template_NormalUserPermissions_Publish = new List<string>


### PR DESCRIPTION
为RestfulApi增加了一个接口POST: /api/Config/MergeUpdate.

用来批量修改一组配置,在请求参数中传一个json字符串,后端解析kv后,与现有配置进行比较,如果配置以前存在并且此次有修改,就更新,如果配置以前不存在,则本次就添加.
同时处理好了权限,增加了相关的权限定义,如: Functions.Config_MergeUpdate

可能修复了这个https://github.com/dotnetcore/AgileConfig/issues/100