### PR TITLE
OrderBy导致的客户端频繁reload

### DIFF
--- a/AgileConfig.Server.Common/StringUtil.cs
+++ b/AgileConfig.Server.Common/StringUtil.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Globalization;
+
+namespace AgileConfig.Server.Common
+{
+    public static class StringUtil
+    {
+        /// <summary>
+        /// 字符串比较器（不区分文化&大小写）
+        /// </summary>
+        public static StringComparer StringComparerWithInvariantCulture { get; } = StringComparer.Create(CultureInfo.InvariantCulture, true);
+    }
+}

--- a/AgileConfig.Server.Service/ConfigService.cs
+++ b/AgileConfig.Server.Service/ConfigService.cs
@@ -428,8 +428,8 @@ namespace AgileConfig.Server.Service
         {
             var configs = await GetPublishedConfigsByAppIdWithInheritanced(appId, env);
 
-            var keyStr = string.Join('&', configs.Select(c => GenerateKey(c)).ToArray().OrderBy(k => k));
-            var valStr = string.Join('&', configs.Select(c => c.Value).ToArray().OrderBy(v => v));
+            var keyStr = string.Join('&', configs.Select(c => GenerateKey(c)).ToArray().OrderBy(k => k, StringUtil.StringComparerWithInvariantCulture));
+            var valStr = string.Join('&', configs.Select(c => c.Value).ToArray().OrderBy(v => v, StringUtil.StringComparerWithInvariantCulture));
             var txt = $"{keyStr}&{valStr}";
 
             return Encrypt.Md5(txt);


### PR DESCRIPTION
Description:
1. 客户端计算配置的MD5时，OrderBy更改为忽略区域文化、大小写的实现，避免服务端和客户端区域文化不一致导致的频繁reload问题。

Issue(s) addressed:
- None

Changes:
- ConfigService.AppPublishedConfigsMd5WithInheritanced

Affected components:
- None

How to test:
- None

Additional notes (optional):
- None

Reviewers:
@kklldog 