### PR TITLE
Disable nullable warnings in 7 csproj files

### DIFF
--- a/src/AgileConfig.Server.Data.Abstraction/AgileConfig.Server.Data.Abstraction.csproj
+++ b/src/AgileConfig.Server.Data.Abstraction/AgileConfig.Server.Data.Abstraction.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AgileConfig.Server.Data.Freesql/AgileConfig.Server.Data.Freesql.csproj
+++ b/src/AgileConfig.Server.Data.Freesql/AgileConfig.Server.Data.Freesql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
 	  <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 

--- a/src/AgileConfig.Server.Data.Mongodb/AgileConfig.Server.Data.Mongodb.csproj
+++ b/src/AgileConfig.Server.Data.Mongodb/AgileConfig.Server.Data.Mongodb.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+        <Nullable>disable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/AgileConfig.Server.Data.Repository.Mongodb/AgileConfig.Server.Data.Repository.Mongodb.csproj
+++ b/src/AgileConfig.Server.Data.Repository.Mongodb/AgileConfig.Server.Data.Repository.Mongodb.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+        <Nullable>disable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/AgileConfig.Server.EventHandler/AgileConfig.Server.EventHandler.csproj
+++ b/src/AgileConfig.Server.EventHandler/AgileConfig.Server.EventHandler.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/AgileConfig.Server.Data.AbstractionTests/AgileConfig.Server.Data.AbstractionTests.csproj
+++ b/test/AgileConfig.Server.Data.AbstractionTests/AgileConfig.Server.Data.AbstractionTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/test/AgileConfig.Server.Data.FreesqlTests/AgileConfig.Server.Data.FreesqlTests.csproj
+++ b/test/AgileConfig.Server.Data.FreesqlTests/AgileConfig.Server.Data.FreesqlTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>


### PR DESCRIPTION
Changed <Nullable>enable</Nullable> to <Nullable>disable</Nullable> in:
- src/AgileConfig.Server.Data.Abstraction
- src/AgileConfig.Server.Data.Freesql
- src/AgileConfig.Server.Data.Mongodb
- src/AgileConfig.Server.Data.Repository.Mongodb
- src/AgileConfig.Server.EventHandler
- test/AgileConfig.Server.Data.AbstractionTests
- test/AgileConfig.Server.Data.FreesqlTests

This reduces build warnings from 150 to 102.