### PR TITLE
feat: support batch app export

### DIFF
--- a/src/AgileConfig.Server.Apisite/Controllers/AppController.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/AppController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using AgileConfig.Server.Apisite.Filters;
 using AgileConfig.Server.Apisite.Models;
@@ -14,6 +15,7 @@ using AgileConfig.Server.Event;
 using AgileConfig.Server.IService;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
 
 namespace AgileConfig.Server.Apisite.Controllers;
 
@@ -22,14 +24,20 @@ namespace AgileConfig.Server.Apisite.Controllers;
 public class AppController : Controller
 {
     private readonly IAppService _appService;
+    private readonly IConfigService _configService;
+    private readonly ISettingService _settingService;
     private readonly ITinyEventBus _tinyEventBus;
     private readonly IUserService _userService;
 
     public AppController(IAppService appService,
         IUserService userService,
+        IConfigService configService,
+        ISettingService settingService,
         ITinyEventBus tinyEventBus)
     {
         _userService = userService;
+        _configService = configService;
+        _settingService = settingService;
         _tinyEventBus = tinyEventBus;
         _appService = appService;
     }
@@ -105,6 +113,26 @@ public class AppController : Controller
                 : inheritancedApps.Select(ia => ia.Name).ToList();
             if (appListVm.children != null) await AppendInheritancedInfo(appListVm.children);
         }
+    }
+
+    private async Task<bool> IsCurrentUserAdmin(string currentUserId)
+    {
+        if (string.IsNullOrWhiteSpace(currentUserId)) return false;
+
+        var roles = await _userService.GetUserRolesAsync(currentUserId);
+        return roles.Any(r => r.Id == SystemRoleConstants.AdminId || r.Id == SystemRoleConstants.SuperAdminId);
+    }
+
+    private async Task<App> GetAuthorizedAppAsync(string appId, string currentUserId, bool isAdmin)
+    {
+        var app = await _appService.GetAsync(appId);
+        if (app == null) return null;
+
+        if (isAdmin) return app;
+
+        var searchResult = await _appService.SearchAsync(appId, null, null, nameof(App.Id), "ascend", 1, 1,
+            currentUserId, false);
+        return searchResult.Apps.FirstOrDefault(x => x.Id == appId);
     }
 
     [TypeFilter(typeof(PermissionCheckAttribute), Arguments = new object[] { Functions.App_Add })]
@@ -271,6 +299,87 @@ public class AppController : Controller
             success = result,
             message = !result ? Messages.UpdateAppFailed : ""
         });
+    }
+
+    [TypeFilter(typeof(PermissionCheckAttribute), Arguments = new object[] { Functions.App_Read })]
+    [HttpPost]
+    public async Task<IActionResult> Export([FromBody] AppExportRequest model)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+
+        var appIds = model.AppIds?
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList() ?? new List<string>();
+        if (!appIds.Any()) throw new ArgumentException("appIds");
+
+        var currentUserId = await this.GetCurrentUserId(_userService);
+        var isAdmin = await IsCurrentUserAdmin(currentUserId);
+
+        var apps = new List<App>();
+        foreach (var appId in appIds)
+        {
+            var app = await GetAuthorizedAppAsync(appId, currentUserId, isAdmin);
+            if (app == null)
+            {
+                Response.StatusCode = 403;
+                return new ContentResult();
+            }
+
+            apps.Add(app);
+        }
+
+        var envs = (await _settingService.GetEnvironmentList())
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToList();
+
+        var exportFile = new AppExportFileVM
+        {
+            ExportedAt = DateTime.UtcNow
+        };
+
+        foreach (var app in apps)
+        {
+            var inheritancedApps = await _appService.GetInheritancedAppsAsync(app.Id);
+            var exportItem = new AppExportItemVM
+            {
+                App = new AppExportAppVM
+                {
+                    Id = app.Id,
+                    Name = app.Name,
+                    Group = app.Group,
+                    Secret = app.Secret,
+                    Enabled = app.Enabled,
+                    Type = (int)app.Type,
+                    Inheritanced = app.Type == AppType.Inheritance,
+                    InheritancedApps = inheritancedApps.Select(x => x.Id).ToList()
+                }
+            };
+
+            foreach (var env in envs)
+            {
+                var configs = await _configService.GetByAppIdAsync(app.Id, env);
+                exportItem.Envs[env] = configs
+                    .OrderBy(x => x.Group ?? string.Empty, StringComparer.Ordinal)
+                    .ThenBy(x => x.Key ?? string.Empty, StringComparer.Ordinal)
+                    .Select(x => new AppExportConfigVM
+                    {
+                        Group = x.Group,
+                        Key = x.Key,
+                        Value = x.Value,
+                        Description = x.Description
+                    })
+                    .ToList();
+            }
+
+            exportFile.Apps.Add(exportItem);
+        }
+
+        var json = JsonConvert.SerializeObject(exportFile, Formatting.Indented);
+        var fileName = $"agileconfig-export-{DateTime.UtcNow:yyyyMMddHHmmss}.json";
+        return File(Encoding.UTF8.GetBytes(json), "application/json", fileName);
     }
 
     /// <summary>

--- a/src/AgileConfig.Server.Apisite/Models/AppExportVM.cs
+++ b/src/AgileConfig.Server.Apisite/Models/AppExportVM.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace AgileConfig.Server.Apisite.Models;
+
+public class AppExportRequest
+{
+    [JsonProperty("appIds")]
+    public List<string> AppIds { get; set; }
+}
+
+public class AppExportFileVM
+{
+    [JsonProperty("schemaVersion")]
+    public int SchemaVersion { get; set; } = 1;
+
+    [JsonProperty("exportedAt")]
+    public DateTime ExportedAt { get; set; }
+
+    [JsonProperty("apps")]
+    public List<AppExportItemVM> Apps { get; set; } = new();
+}
+
+public class AppExportItemVM
+{
+    [JsonProperty("app")]
+    public AppExportAppVM App { get; set; }
+
+    [JsonProperty("envs")]
+    public Dictionary<string, List<AppExportConfigVM>> Envs { get; set; } = new();
+}
+
+public class AppExportAppVM
+{
+    [JsonProperty("id")]
+    public string Id { get; set; }
+
+    [JsonProperty("name")]
+    public string Name { get; set; }
+
+    [JsonProperty("group")]
+    public string Group { get; set; }
+
+    [JsonProperty("secret")]
+    public string Secret { get; set; }
+
+    [JsonProperty("enabled")]
+    public bool Enabled { get; set; }
+
+    [JsonProperty("type")]
+    public int Type { get; set; }
+
+    [JsonProperty("inheritanced")]
+    public bool Inheritanced { get; set; }
+
+    [JsonProperty("inheritancedApps")]
+    public List<string> InheritancedApps { get; set; } = new();
+}
+
+public class AppExportConfigVM
+{
+    [JsonProperty("group")]
+    public string Group { get; set; }
+
+    [JsonProperty("key")]
+    public string Key { get; set; }
+
+    [JsonProperty("value")]
+    public string Value { get; set; }
+
+    [JsonProperty("description")]
+    public string Description { get; set; }
+}

--- a/src/AgileConfig.Server.UI/react-ui-antd/src/pages/Apps/index.tsx
+++ b/src/AgileConfig.Server.UI/react-ui-antd/src/pages/Apps/index.tsx
@@ -1,4 +1,4 @@
-import { ExclamationCircleOutlined, PlusOutlined } from '@ant-design/icons';
+import { DownloadOutlined, ExclamationCircleOutlined, PlusOutlined } from '@ant-design/icons';
 import {
   ModalForm,
   ProFormDependency,
@@ -20,7 +20,7 @@ import {
   Switch,
   Tag,
 } from 'antd';
-import React, { useState, useRef, useEffect } from 'react';
+import React, { Key, useState, useRef, useEffect } from 'react';
 import { getIntl, getLocale, Link, useIntl } from 'umi';
 import UpdateForm from './comps/updateForm';
 import { AppListItem, AppListParams, AppListResult, UserAppAuth } from './data';
@@ -33,6 +33,7 @@ import {
   enableOrdisableApp,
   saveAppAuth,
   getAppGroups,
+  exportApps,
 } from './service';
 import UserAuth from './comps/userAuth';
 import AuthorizedEle from '@/components/Authorized/AuthorizedElement';
@@ -182,6 +183,38 @@ const handleUserAppAuth = async (model: UserAppAuth) => {
   }
 };
 
+const buildExportFileName = () => {
+  const date = new Date();
+  const pad = (value: number) => value.toString().padStart(2, '0');
+  return `agileconfig-export-${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(
+    date.getDate(),
+  )}${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}.json`;
+};
+
+const handleExportApps = async (apps: AppListItem[]) => {
+  const intl = getIntl(getLocale());
+  const hide = message.loading('导出中...');
+  try {
+    const file = await exportApps(apps.map((item) => item.id));
+    hide();
+    const fileURL = URL.createObjectURL(file);
+    const a = document.createElement('a');
+    a.href = fileURL;
+    a.target = '_blank';
+    a.download = buildExportFileName();
+    document.body.appendChild(a);
+    a.click();
+    URL.revokeObjectURL(a.href);
+    document.body.removeChild(a);
+    message.success('导出成功');
+    return true;
+  } catch (error) {
+    hide();
+    message.error(intl.formatMessage({ id: 'save_fail' }));
+    return false;
+  }
+};
+
 const appList: React.FC = (props) => {
   const actionRef = useRef<ActionType>();
   const addFormRef = useRef<FormInstance>();
@@ -193,6 +226,8 @@ const appList: React.FC = (props) => {
   const [userAuthModalVisible, setUserAuthModalVisible] = useState<boolean>(false);
   const [currentRow, setCurrentRow] = useState<AppListItem>();
   const [dataSource, setDataSource] = useState<AppListResult>();
+  const [selectedRowKeysState, setSelectedRowKeys] = useState<Key[]>([]);
+  const [selectedRowsState, setSelectedRows] = useState<AppListItem[]>([]);
   const [appGroups, setAppGroups] = useState<{ label: string; value: string }[]>([]);
   const [newAppGroupName, setNewAppGroupName] = useState<string>('');
   const [appGroupsEnums, setAppGroupsEnums] = useState<{}>({});
@@ -440,6 +475,13 @@ const appList: React.FC = (props) => {
       <ProTable
         actionRef={actionRef}
         options={false}
+        rowSelection={{
+          selectedRowKeys: selectedRowKeysState,
+          onChange: (selectedRowKeys, selectedRows) => {
+            setSelectedRowKeys(selectedRowKeys);
+            setSelectedRows(selectedRows as AppListItem[]);
+          },
+        }}
         search={{
           labelWidth: 'auto',
         }}
@@ -484,6 +526,22 @@ const appList: React.FC = (props) => {
                 {intl.formatMessage({
                   id: 'pages.app.table.cols.action.add',
                 })}
+              </Button>
+            </AuthorizedEle>,
+            <AuthorizedEle key="1" judgeKey={functionKeys.App_Read}>
+              <Button
+                key="export"
+                icon={<DownloadOutlined />}
+                disabled={selectedRowsState.length === 0}
+                onClick={async () => {
+                  const success = await handleExportApps(selectedRowsState);
+                  if (success) {
+                    setSelectedRowKeys([]);
+                    setSelectedRows([]);
+                  }
+                }}
+              >
+                导出
               </Button>
             </AuthorizedEle>,
           ];

--- a/src/AgileConfig.Server.UI/react-ui-antd/src/pages/Apps/service.ts
+++ b/src/AgileConfig.Server.UI/react-ui-antd/src/pages/Apps/service.ts
@@ -70,3 +70,13 @@ export async function getAppGroups() {
     method: 'GET',
   });
 }
+
+export async function exportApps(appIds: string[]) {
+  return request('app/Export', {
+    method: 'POST',
+    data: {
+      appIds,
+    },
+    responseType: 'blob',
+  });
+}

--- a/test/ApiSiteTests/TestAppController.cs
+++ b/test/ApiSiteTests/TestAppController.cs
@@ -26,9 +26,12 @@ public class TestAppController
         var logService = new Mock<ISysLogService>();
         var userService = new Mock<IUserService>();
         var permissionService = new Mock<IPermissionService>();
+        var configService = new Mock<IConfigService>();
+        var settingService = new Mock<ISettingService>();
         var eventBus = new Mock<ITinyEventBus>();
 
-        var ctl = new AppController(appService.Object, userService.Object, eventBus.Object);
+        var ctl = new AppController(appService.Object, userService.Object, configService.Object, settingService.Object,
+            eventBus.Object);
 
         ctl.ControllerContext.HttpContext = new DefaultHttpContext();
 


### PR DESCRIPTION
## Summary
- add a new app-level batch export endpoint that exports selected apps, app metadata, inheritance, and latest configs for all environments into a single JSON file
- add app-list multi-select + toolbar export button in the React UI
- update the existing AppController unit test constructor wiring

## Testing
- `dotnet build AgileConfig.sln -c Release`
- `npm ci`
- `npm run tsc` *(currently fails because the repo already has many unrelated TypeScript issues outside this change, so only backend build is green for this PR)*

Closes #235