### PR TITLE
ci: remove redundant build-reactapp job from publish and test-cd

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,30 +9,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-reactapp:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: src/AgileConfig.Server.UI/react-ui-antd
-    strategy:
-      matrix:
-        node-version: [16.x]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-        
-    - run: npm install
-    - run: npm run build
-    - uses: actions/upload-artifact@v4
-      with:
-        name: agileconfig-ui
-        path: src/AgileConfig.Server.UI/react-ui-antd/dist/
+  # The React admin UI is built inside the Dockerfile (ui-build stage), so there
+  # is no separate build-reactapp job here.
   build-dotnet-push-to-hub:
-    needs: build-reactapp
     runs-on: ubuntu-latest
 
     steps:
@@ -48,10 +27,6 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --configuration Release --no-restore
-    - uses: actions/download-artifact@v4
-      with:
-        name: agileconfig-ui
-        path: src/AgileConfig.Server.Apisite/wwwroot/ui
     - name: Push to Docker Hub
       uses: docker/build-push-action@v1
       with:

--- a/.github/workflows/test-cd.yml
+++ b/.github/workflows/test-cd.yml
@@ -9,32 +9,9 @@ on:
       - 'test-*'
   workflow_dispatch:  
 jobs:
-  build-reactapp:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: src/AgileConfig.Server.UI/react-ui-antd
-    strategy:
-      matrix:
-        node-version: [16.x]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-        
-    - run: npm install
-    - run: npm run build
-    
-    - uses: actions/upload-artifact@v4
-      with:
-        name: agileconfig-ui
-        path: src/AgileConfig.Server.UI/react-ui-antd/dist/
-        
+  # The React admin UI is built inside the Dockerfile (ui-build stage), so there
+  # is no separate build-reactapp job here.
   build-dotnet-push-to-hub:
-    needs: build-reactapp
     runs-on: ubuntu-latest
 
     steps:
@@ -51,12 +28,7 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --configuration Release --no-restore
-      
-    - uses: actions/download-artifact@v4
-      with:
-        name: agileconfig-ui
-        path: src/AgileConfig.Server.Apisite/wwwroot/ui
-        
+
     - name: Push to Docker Hub
       uses: docker/build-push-action@v1
       with:


### PR DESCRIPTION
Follow-up to #240, which added a `ui-build` stage to the Dockerfile so the image builds the React admin UI itself.

With that in place, `publish.yml` and `test-cd.yml` were building the UI **twice** per release: once in a dedicated `build-reactapp` job that uploaded `dist/` as an artifact, and again inside `docker build`. The artifact was downloaded into `src/AgileConfig.Server.Apisite/wwwroot/ui` before the Docker step, but the in-Docker build overwrites that path anyway — so the CI job's output was silently discarded.

This removes the redundant job from those two workflows, leaving a single UI build path and keeping `docker build .` reproducible outside of CI.

### Changed

- `publish.yml` — removed `build-reactapp` job, its `needs:` edge, and the `download-artifact` step
- `test-cd.yml` — same

### Deliberately left alone

- **`master-ci.yml` / `master-pr-ci.yml`** — their `build-reactapp` is compile-only (`npm run build`, no artifact, no downstream job). It's the only CI gate that catches frontend build errors on a PR, and neither workflow builds an image, so the Dockerfile can't cover it. Kept.
- **`release-xxx.yml`** — besides the Docker push it produces a zip release artifact via `dotnet publish`, which needs the frontend in `wwwroot/ui` and never goes through the Dockerfile. Kept.
- **`arm32.yml` / `arm64.yml` / `mysqlconnector.yml`** — these run on their own long-lived branches whose Dockerfiles have no `ui-build` stage. They still carry their own `build-reactapp` job, so image builds on those branches are unaffected by this PR. Those branches are 1.5–3.5 years behind master and merging it in is a large, separate piece of work — tracked separately rather than bundled here.

### Verification

Both files parse cleanly and each now contains exactly one job with no dangling `needs`. Net −58/+5 lines.
