### PR TITLE
我在尝试从1.10.0升级到最新版本的时候，发现实体的数据结构有变更，为了更丝滑的升级，我给实体类添加了 BsonIgnoreExtraElements

### DIFF
--- a/src/AgileConfig.Server.Data.Entity/AgileConfig.Server.Data.Entity.csproj
+++ b/src/AgileConfig.Server.Data.Entity/AgileConfig.Server.Data.Entity.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="FreeSql" Version="3.5.303" />
-    <PackageReference Include="MongoDB.Bson" Version="3.5.1" />
+    <PackageReference Include="MongoDB.Bson" Version="3.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AgileConfig.Server.Data.Entity/App.cs
+++ b/src/AgileConfig.Server.Data.Entity/App.cs
@@ -26,6 +26,7 @@ public enum AppType
 
 [Table(Name = "agc_app")]
 [OraclePrimaryKeyName("agc_app_pk")]
+[BsonIgnoreExtraElements]
 public class App : IAppModel, IEntity<string>
 {
     [Column(Name = "secret", StringLength = 36)]

--- a/src/AgileConfig.Server.Data.Entity/AppInheritanced.cs
+++ b/src/AgileConfig.Server.Data.Entity/AppInheritanced.cs
@@ -1,5 +1,6 @@
 ﻿using AgileConfig.Server.Common;
 using FreeSql.DataAnnotations;
+using MongoDB.Bson.Serialization.Attributes;
 
 namespace AgileConfig.Server.Data.Entity;
 
@@ -8,6 +9,7 @@ namespace AgileConfig.Server.Data.Entity;
 /// </summary>
 [Table(Name = "agc_appInheritanced")]
 [OraclePrimaryKeyName("agc_appInheritanced_pk")]
+[BsonIgnoreExtraElements]
 public class AppInheritanced : IEntity<string>
 {
     [Column(Name = "appid", StringLength = 36)]

--- a/src/AgileConfig.Server.Data.Entity/Config.cs
+++ b/src/AgileConfig.Server.Data.Entity/Config.cs
@@ -41,6 +41,7 @@ public enum OnlineStatus
 
 [Table(Name = "agc_config")]
 [OraclePrimaryKeyName("agc_config_pk")]
+[BsonIgnoreExtraElements]
 public class Config : IEntity<string>
 {
     [Column(Name = "app_id", StringLength = 36)]

--- a/src/AgileConfig.Server.Data.Entity/ConfigPublished.cs
+++ b/src/AgileConfig.Server.Data.Entity/ConfigPublished.cs
@@ -7,6 +7,7 @@ namespace AgileConfig.Server.Data.Entity;
 
 [Table(Name = "agc_config_published")]
 [OraclePrimaryKeyName("agc_config_published_pk")]
+[BsonIgnoreExtraElements]
 public class ConfigPublished : IEntity<string>
 {
     [Column(Name = "app_id", StringLength = 36)]

--- a/src/AgileConfig.Server.Data.Entity/Function.cs
+++ b/src/AgileConfig.Server.Data.Entity/Function.cs
@@ -7,6 +7,7 @@ namespace AgileConfig.Server.Data.Entity;
 
 [Table(Name = "agc_function")]
 [OraclePrimaryKeyName("agc_function_pk")]
+[BsonIgnoreExtraElements]
 public class Function : IEntity<string>
 {
     [Column(Name = "code", StringLength = 64)]

--- a/src/AgileConfig.Server.Data.Entity/PublishDetail.cs
+++ b/src/AgileConfig.Server.Data.Entity/PublishDetail.cs
@@ -1,10 +1,12 @@
 ﻿using AgileConfig.Server.Common;
 using FreeSql.DataAnnotations;
+using MongoDB.Bson.Serialization.Attributes;
 
 namespace AgileConfig.Server.Data.Entity;
 
 [Table(Name = "agc_publish_detail")]
 [OraclePrimaryKeyName("agc_publish_detail_pk")]
+[BsonIgnoreExtraElements]
 public class PublishDetail : IEntity<string>
 {
     [Column(Name = "app_id", StringLength = 36)]

--- a/src/AgileConfig.Server.Data.Entity/PublishTimeline.cs
+++ b/src/AgileConfig.Server.Data.Entity/PublishTimeline.cs
@@ -7,6 +7,7 @@ namespace AgileConfig.Server.Data.Entity;
 
 [Table(Name = "agc_publish_timeline")]
 [OraclePrimaryKeyName("agc_publish_timeline_pk")]
+[BsonIgnoreExtraElements]
 public class PublishTimeline : IEntity<string>
 {
     [Column(Name = "app_id", StringLength = 36)]

--- a/src/AgileConfig.Server.Data.Entity/RoleDefinition.cs
+++ b/src/AgileConfig.Server.Data.Entity/RoleDefinition.cs
@@ -7,6 +7,7 @@ namespace AgileConfig.Server.Data.Entity;
 
 [Table(Name = "agc_role")]
 [OraclePrimaryKeyName("agc_role_pk")]
+[BsonIgnoreExtraElements]
 public class Role : IEntity<string>
 {
     [Column(Name = "name", StringLength = 128)]

--- a/src/AgileConfig.Server.Data.Entity/RoleFunction.cs
+++ b/src/AgileConfig.Server.Data.Entity/RoleFunction.cs
@@ -7,6 +7,7 @@ namespace AgileConfig.Server.Data.Entity;
 
 [Table(Name = "agc_role_function")]
 [OraclePrimaryKeyName("agc_role_function_pk")]
+[BsonIgnoreExtraElements]
 public class RoleFunction : IEntity<string>
 {
     [Column(Name = "role_id", StringLength = 64)]

--- a/src/AgileConfig.Server.Data.Entity/ServerNode.cs
+++ b/src/AgileConfig.Server.Data.Entity/ServerNode.cs
@@ -17,6 +17,7 @@ public enum NodeStatus
 
 [Table(Name = "agc_server_node")]
 [OraclePrimaryKeyName("agc_server_node_pk")]
+[BsonIgnoreExtraElements]
 public class ServerNode : IEntity<string>
 {
     [Column(Name = "remark", StringLength = 50)]

--- a/src/AgileConfig.Server.Data.Entity/ServiceInfo.cs
+++ b/src/AgileConfig.Server.Data.Entity/ServiceInfo.cs
@@ -26,6 +26,7 @@ public enum HeartBeatModes
 
 [Table(Name = "agc_service_info")]
 [OraclePrimaryKeyName("agc_serviceinfo_pk")]
+[BsonIgnoreExtraElements]
 public class ServiceInfo : IEntity<string>
 {
     [Column(Name = "service_id", StringLength = 100)]

--- a/src/AgileConfig.Server.Data.Entity/Setting.cs
+++ b/src/AgileConfig.Server.Data.Entity/Setting.cs
@@ -7,6 +7,7 @@ namespace AgileConfig.Server.Data.Entity;
 
 [Table(Name = "agc_setting")]
 [OraclePrimaryKeyName("agc_setting_pk")]
+[BsonIgnoreExtraElements]
 public class Setting : IEntity<string>
 {
     [Column(Name = "value", StringLength = 200)]

--- a/src/AgileConfig.Server.Data.Entity/SysLog.cs
+++ b/src/AgileConfig.Server.Data.Entity/SysLog.cs
@@ -13,6 +13,7 @@ public enum SysLogType
 
 [Table(Name = "agc_sys_log")]
 [OraclePrimaryKeyName("agc_sys_log_pk")]
+[BsonIgnoreExtraElements]
 public class SysLog : IEntity<string>
 {
     public SysLog()

--- a/src/AgileConfig.Server.Data.Entity/User.cs
+++ b/src/AgileConfig.Server.Data.Entity/User.cs
@@ -7,6 +7,7 @@ namespace AgileConfig.Server.Data.Entity;
 
 [Table(Name = "agc_user")]
 [OraclePrimaryKeyName("agc_user_pk")]
+[BsonIgnoreExtraElements]
 public class User : IEntity<string>
 {
     [Column(Name = "user_name", StringLength = 256)]

--- a/src/AgileConfig.Server.Data.Entity/UserAppAuth.cs
+++ b/src/AgileConfig.Server.Data.Entity/UserAppAuth.cs
@@ -1,10 +1,12 @@
 ﻿using AgileConfig.Server.Common;
 using FreeSql.DataAnnotations;
+using MongoDB.Bson.Serialization.Attributes;
 
 namespace AgileConfig.Server.Data.Entity;
 
 [Table(Name = "agc_user_app_auth")]
 [OraclePrimaryKeyName("agc_user_app_auth_pk")]
+[BsonIgnoreExtraElements]
 public class UserAppAuth : IEntity<string>
 {
     [Column(Name = "app_id", StringLength = 36)]

--- a/src/AgileConfig.Server.Data.Entity/UserRole.cs
+++ b/src/AgileConfig.Server.Data.Entity/UserRole.cs
@@ -7,6 +7,7 @@ namespace AgileConfig.Server.Data.Entity;
 
 [Table(Name = "agc_user_role")]
 [OraclePrimaryKeyName("agc_user_role_pk")]
+[BsonIgnoreExtraElements]
 public class UserRole : IEntity<string>
 {
     [Column(Name = "user_id", StringLength = 50)]

--- a/src/AgileConfig.Server.Data.Mongodb/AgileConfig.Server.Data.Mongodb.csproj
+++ b/src/AgileConfig.Server.Data.Mongodb/AgileConfig.Server.Data.Mongodb.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
         <PackageReference Include="MongoDB.Analyzer" Version="2.0.0" />
-        <PackageReference Include="MongoDB.Driver" Version="3.9.0" />
+        <PackageReference Include="MongoDB.Driver" Version="3.10.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
feat: MongoDB 反序列化忽略多余字段

- 为 App、Config、User、Setting、ServerNode、ServiceInfo、SysLog 等全部实体类添加 `[BsonIgnoreExtraElements]` 特性，使 MongoDB 读取文档时忽略多余的字段
- 为 AppInheritanced、PublishDetail、UserAppAuth 补充 `MongoDB.Bson.Serialization.Attributes` 引用
- 升级 MongoDB.Bson 包版本 3.5.1 → 3.10.0
- 升级 MongoDB.Driver 包版本 3.9.0 → 3.10.0

## Summary

Describe what changed and why.

## User-facing changes

Describe the behavior visible to users, or write `None` for internal-only changes.

## Release notes

Maintainers: apply the most appropriate release label before merging. Use
`skip-release-notes` only when this pull request should not appear in a release.

- `breaking-change`
- `enhancement` or `feature`
- `bug` or `fix`
- `performance`
- `security`
- `dependencies`, `build`, or `ci`
- `documentation`

## Verification

Describe the tests or checks performed.
