### PR TITLE
feat(ui): add dark mode

### DIFF
--- a/src/AgileConfig.Server.Apisite/AgileConfig.Server.Apisite.csproj
+++ b/src/AgileConfig.Server.Apisite/AgileConfig.Server.Apisite.csproj
@@ -3,11 +3,11 @@
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
-		<AssemblyVersion>1.12.7</AssemblyVersion>
-		<Version>1.12.7</Version>
-		<PackageVersion>1.12.7</PackageVersion>
+		<AssemblyVersion>1.12.8</AssemblyVersion>
+		<Version>1.12.8</Version>
+		<PackageVersion>1.12.8</PackageVersion>
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-		<FileVersion>1.12.7</FileVersion>
+		<FileVersion>1.12.8</FileVersion>
 		<Authors>kklldog</Authors>
 		<Company>kklldog</Company>
 	</PropertyGroup>

--- a/src/AgileConfig.Server.UI/react-ui-antd/config/defaultSettings.ts
+++ b/src/AgileConfig.Server.UI/react-ui-antd/config/defaultSettings.ts
@@ -2,6 +2,7 @@ import { Settings as ProSettings } from '@ant-design/pro-layout';
 
 type DefaultSettings = Partial<ProSettings> & {
   pwa: boolean;
+  darkMode: boolean;
 };
 
 const proSettings: DefaultSettings ={
@@ -13,6 +14,7 @@ const proSettings: DefaultSettings ={
   "fixSiderbar": true,
   "title": "AgileConfig",
   "pwa": false,
+  "darkMode": false,
   "iconfontUrl": "",
   "menu": {
     "locale": true

--- a/src/AgileConfig.Server.UI/react-ui-antd/src/components/GlobalHeader/RightContent.tsx
+++ b/src/AgileConfig.Server.UI/react-ui-antd/src/components/GlobalHeader/RightContent.tsx
@@ -1,14 +1,16 @@
-import { Tag } from 'antd';
+import { BulbFilled, BulbOutlined } from '@ant-design/icons';
+import { Tag, Tooltip } from 'antd';
 import type { Settings as ProSettings } from '@ant-design/pro-layout';
 import React from 'react';
 import type { ConnectProps } from 'umi';
-import { connect, SelectLang } from 'umi';
+import { connect, SelectLang, useIntl } from 'umi';
 import type { ConnectState } from '@/models/connect';
 import Avatar from './AvatarDropdown';
 import styles from './index.less';
 
 export type GlobalHeaderRightProps = {
   theme?: ProSettings['navTheme'] | 'realDark';
+  darkMode?: boolean;
 } & Partial<ConnectProps> &
   Partial<ProSettings>;
 
@@ -20,6 +22,8 @@ const ENVTagColor = {
 
 const GlobalHeaderRight: React.SFC<GlobalHeaderRightProps> = (props) => {
   const { theme, layout } = props;
+  const { formatMessage } = useIntl();
+  const darkMode = !!props.darkMode;
   let className = styles.right;
 
   if (theme === 'dark' && layout === 'top') {
@@ -28,6 +32,29 @@ const GlobalHeaderRight: React.SFC<GlobalHeaderRightProps> = (props) => {
 
   return (
     <div className={className}>
+      <Tooltip
+        title={formatMessage({
+          id: darkMode ? 'component.globalHeader.theme.light' : 'component.globalHeader.theme.dark',
+        })}
+      >
+        <span
+          aria-label={formatMessage({
+            id: darkMode ? 'component.globalHeader.theme.light' : 'component.globalHeader.theme.dark',
+          })}
+          className={styles.action}
+          role="button"
+          tabIndex={0}
+          onClick={() => props.dispatch?.({ type: 'settings/changeSetting', payload: { darkMode: !darkMode } })}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              props.dispatch?.({ type: 'settings/changeSetting', payload: { darkMode: !darkMode } });
+            }
+          }}
+        >
+          {darkMode ? <BulbFilled /> : <BulbOutlined />}
+        </span>
+      </Tooltip>
       <Avatar />
       {REACT_APP_ENV && (
         <span>
@@ -40,6 +67,7 @@ const GlobalHeaderRight: React.SFC<GlobalHeaderRightProps> = (props) => {
 };
 
 export default connect(({ settings }: ConnectState) => ({
-  theme: settings.navTheme,
+  theme: settings.darkMode ? 'dark' : settings.navTheme,
   layout: settings.layout,
+  darkMode: settings.darkMode,
 }))(GlobalHeaderRight);

--- a/src/AgileConfig.Server.UI/react-ui-antd/src/global.less
+++ b/src/AgileConfig.Server.UI/react-ui-antd/src/global.less
@@ -81,3 +81,181 @@ ol {
   border-color:#73d13d;
   background-color: #73d13d;
 }
+
+// Ant Design 4 generates its component palette at build time. These scoped
+// overrides keep the runtime theme switch consistent across application views.
+html.dark-mode {
+  color-scheme: dark;
+
+  body,
+  #root,
+  .ant-layout,
+  .ant-pro-basicLayout,
+  .ant-pro-basicLayout-content,
+  .ant-pro-page-container,
+  .ant-pro-grid-content,
+  .ant-pro-page-container-children-content {
+    color: rgba(255, 255, 255, 0.85);
+    background: #141414;
+  }
+
+  .ant-pro-global-header,
+  .ant-pro-global-header .ant-pro-global-header-layout-mix,
+  .ant-pro-sider,
+  .ant-layout-sider {
+    background: #1f1f1f;
+  }
+
+  .ant-card,
+  .ant-modal-content,
+  .ant-drawer-content,
+  .ant-dropdown-menu,
+  .ant-popover-inner,
+  .ant-select-dropdown,
+  .ant-picker-dropdown,
+  .ant-cascader-menu,
+  .ant-menu-submenu-popup,
+  .ant-message-notice-content,
+  .ant-notification-notice,
+  .ant-tooltip-inner {
+    color: rgba(255, 255, 255, 0.85);
+    background: #1f1f1f;
+  }
+
+  .ant-card,
+  .ant-modal-header,
+  .ant-modal-footer,
+  .ant-drawer-header,
+  .ant-popover-inner,
+  .ant-dropdown-menu,
+  .ant-select-dropdown,
+  .ant-picker-panel-container,
+  .ant-table,
+  .ant-table-container,
+  .ant-descriptions-bordered .ant-descriptions-item-label,
+  .ant-descriptions-bordered .ant-descriptions-item-content {
+    border-color: #434343;
+  }
+
+  .ant-modal-header,
+  .ant-drawer-header,
+  .ant-table,
+  .ant-table-container,
+  .ant-table-thead > tr > th,
+  .ant-table-tbody > tr > td,
+  .ant-descriptions-bordered .ant-descriptions-item-label,
+  .ant-descriptions-bordered .ant-descriptions-item-content,
+  .ant-list-item,
+  .ant-collapse,
+  .ant-collapse > .ant-collapse-item,
+  .ant-tabs-top > .ant-tabs-nav::before,
+  .ant-tabs-bottom > .ant-tabs-nav::before,
+  .ant-tabs-top > div > .ant-tabs-nav::before,
+  .ant-tabs-bottom > div > .ant-tabs-nav::before {
+    border-color: #434343;
+  }
+
+  .ant-modal-header,
+  .ant-drawer-header,
+  .ant-table-thead > tr > th,
+  .ant-descriptions-bordered .ant-descriptions-item-label,
+  .ant-collapse,
+  .ant-collapse > .ant-collapse-item,
+  .ant-pagination-item,
+  .ant-pagination-prev .ant-pagination-item-link,
+  .ant-pagination-next .ant-pagination-item-link {
+    background: #262626;
+  }
+
+  .ant-table-tbody > tr > td,
+  .ant-table-tbody > tr.ant-table-row:hover > td,
+  .ant-descriptions-bordered .ant-descriptions-item-content,
+  .ant-collapse-content,
+  .ant-collapse-content > .ant-collapse-content-box {
+    color: rgba(255, 255, 255, 0.85);
+    background: #1f1f1f;
+  }
+
+  .ant-input,
+  .ant-input-affix-wrapper,
+  .ant-input-number,
+  .ant-input-number-input,
+  .ant-select:not(.ant-select-customize-input) .ant-select-selector,
+  .ant-picker,
+  .ant-mentions,
+  .ant-transfer-list,
+  .ant-btn:not(.ant-btn-primary):not(.danger):not(.warn):not(.success) {
+    color: rgba(255, 255, 255, 0.85);
+    background: #141414;
+    border-color: #434343;
+  }
+
+  .ant-input::placeholder,
+  .ant-input-number-input::placeholder,
+  .ant-select-selection-placeholder,
+  .ant-empty-description,
+  .ant-form-item-label > label,
+  .ant-descriptions-title,
+  .ant-modal-title,
+  .ant-drawer-title,
+  .ant-list-item-meta-title,
+  .ant-statistic-title,
+  .ant-page-header-heading-title {
+    color: rgba(255, 255, 255, 0.65);
+  }
+
+  .ant-select-item,
+  .ant-dropdown-menu-item,
+  .ant-dropdown-menu-submenu-title,
+  .ant-menu-item,
+  .ant-menu-submenu-title,
+  .ant-picker-cell,
+  .ant-picker-header,
+  .ant-picker-content th,
+  .ant-pagination-item a,
+  .ant-pagination-prev .ant-pagination-item-link,
+  .ant-pagination-next .ant-pagination-item-link,
+  .ant-tabs-tab,
+  .ant-list-item,
+  .ant-descriptions-item-label,
+  .ant-descriptions-item-content {
+    color: rgba(255, 255, 255, 0.85);
+  }
+
+  .ant-select-item-option-active:not(.ant-select-item-option-disabled),
+  .ant-dropdown-menu-item:hover,
+  .ant-dropdown-menu-submenu-title:hover,
+  .ant-picker-cell-in-view.ant-picker-cell-selected .ant-picker-cell-inner,
+  .ant-picker-cell-in-view.ant-picker-cell-in-range::before {
+    background: #303030;
+  }
+
+  .ant-pagination-item-active {
+    border-color: @primary-color;
+  }
+
+  .ant-pagination-item-active a,
+  .ant-tabs-tab.ant-tabs-tab-active .ant-tabs-tab-btn,
+  .ant-picker-cell-in-view.ant-picker-cell-today .ant-picker-cell-inner::before {
+    color: @primary-color;
+  }
+
+  .ant-result-title,
+  .ant-result-subtitle,
+  .ant-typography,
+  .ant-typography h1,
+  .ant-typography h2,
+  .ant-typography h3,
+  .ant-typography h4,
+  .ant-typography h5,
+  .ant-typography h6 {
+    color: rgba(255, 255, 255, 0.85);
+  }
+
+  .ant-pro-table .ant-card,
+  .ant-pro-page-container-children-container,
+  .ant-pro-page-container-content {
+    background: transparent;
+  }
+
+}

--- a/src/AgileConfig.Server.UI/react-ui-antd/src/layouts/BasicLayout.tsx
+++ b/src/AgileConfig.Server.UI/react-ui-antd/src/layouts/BasicLayout.tsx
@@ -6,7 +6,6 @@
 import {
   MenuDataItem,
   BasicLayoutProps as ProLayoutProps,
-  Settings,
 } from '@ant-design/pro-layout';
 import ProLayout from '@ant-design/pro-layout';
 import React, { useEffect, useMemo, useRef, useCallback } from 'react';
@@ -20,6 +19,7 @@ import type { ConnectState } from '@/models/connect';
 import { getMatchMenu } from '@umijs/route-utils';
 import logo from '../assets/logo.svg';
 import LayoutFooter from './compos/LayoutFooter';
+import type { DefaultSettings } from '../../config/defaultSettings';
 
 const noMatch = (
   <Result
@@ -39,7 +39,7 @@ export type BasicLayoutProps = {
     authority: string[];
   };
   categories?: string[];
-  settings: Settings;
+  settings: DefaultSettings;
   dispatch: Dispatch;
 } & ProLayoutProps;
 export type BasicLayoutContext = { [K in 'location']: BasicLayoutProps[K] } & {
@@ -119,6 +119,7 @@ const BasicLayout: React.FC<BasicLayoutProps> = (props) => {
   );
 
   const { formatMessage } = useIntl();
+  const { darkMode } = settings;
 
   return (
     <ProLayout
@@ -127,6 +128,8 @@ const BasicLayout: React.FC<BasicLayoutProps> = (props) => {
       formatMessage={formatMessage}
       {...props}
       {...settings}
+      navTheme={darkMode ? 'realDark' : settings.navTheme}
+      headerTheme={darkMode ? 'dark' : settings.headerTheme}
       onCollapse={handleMenuCollapse}
       onMenuHeaderClick={() => history.push('/')}
       menuItemRender={(menuItemProps, defaultDom) => {

--- a/src/AgileConfig.Server.UI/react-ui-antd/src/layouts/UserLayout.less
+++ b/src/AgileConfig.Server.UI/react-ui-antd/src/layouts/UserLayout.less
@@ -69,3 +69,19 @@
   color: @text-color-secondary;
   font-size: @font-size-base;
 }
+
+:global(html.dark-mode) {
+  .container {
+    background: #141414;
+  }
+
+  @media (min-width: @screen-md-min) {
+    .container {
+      background-image: none;
+    }
+  }
+
+  .title {
+    color: rgba(255, 255, 255, 0.85);
+  }
+}

--- a/src/AgileConfig.Server.UI/react-ui-antd/src/locales/en-US/globalHeader.ts
+++ b/src/AgileConfig.Server.UI/react-ui-antd/src/locales/en-US/globalHeader.ts
@@ -4,6 +4,8 @@ export default {
   'component.globalHeader.search.example2': 'Search example 2',
   'component.globalHeader.search.example3': 'Search example 3',
   'component.globalHeader.help': 'Help',
+  'component.globalHeader.theme.dark': 'Switch to dark mode',
+  'component.globalHeader.theme.light': 'Switch to light mode',
   'component.globalHeader.notification': 'Notification',
   'component.globalHeader.notification.empty': 'You have viewed all notifications.',
   'component.globalHeader.message': 'Message',

--- a/src/AgileConfig.Server.UI/react-ui-antd/src/locales/zh-CN/globalHeader.ts
+++ b/src/AgileConfig.Server.UI/react-ui-antd/src/locales/zh-CN/globalHeader.ts
@@ -4,6 +4,8 @@ export default {
   'component.globalHeader.search.example2': '搜索提示二',
   'component.globalHeader.search.example3': '搜索提示三',
   'component.globalHeader.help': '使用文档',
+  'component.globalHeader.theme.dark': '切换到深色模式',
+  'component.globalHeader.theme.light': '切换到浅色模式',
   'component.globalHeader.notification': '通知',
   'component.globalHeader.notification.empty': '你已查看所有通知',
   'component.globalHeader.message': '消息',

--- a/src/AgileConfig.Server.UI/react-ui-antd/src/models/connect.d.ts
+++ b/src/AgileConfig.Server.UI/react-ui-antd/src/models/connect.d.ts
@@ -1,7 +1,8 @@
-import type { MenuDataItem, Settings as ProSettings } from '@ant-design/pro-layout';
+import type { MenuDataItem } from '@ant-design/pro-layout';
 import { GlobalModelState } from './global';
 import { UserModelState } from './user';
 import type { StateType } from './login';
+import type { DefaultSettings } from '../../config/defaultSettings';
 
 export { GlobalModelState, UserModelState };
 
@@ -20,7 +21,7 @@ export type Loading = {
 export type ConnectState = {
   global: GlobalModelState;
   loading: Loading;
-  settings: ProSettings;
+  settings: DefaultSettings;
   user: UserModelState;
   login: StateType;
 };

--- a/src/AgileConfig.Server.UI/react-ui-antd/src/models/setting.ts
+++ b/src/AgileConfig.Server.UI/react-ui-antd/src/models/setting.ts
@@ -1,6 +1,7 @@
 import type { Reducer } from 'umi';
 import type { DefaultSettings } from '../../config/defaultSettings';
 import defaultSettings from '../../config/defaultSettings';
+import { applyDarkMode, getStoredDarkMode } from '@/utils/theme';
 
 export type SettingModelType = {
   namespace: 'settings';
@@ -17,17 +18,27 @@ const updateColorWeak: (colorWeak: boolean) => void = (colorWeak) => {
   }
 };
 
+const initialSettings: DefaultSettings = {
+  ...defaultSettings,
+  darkMode: getStoredDarkMode(),
+};
+
+applyDarkMode(initialSettings.darkMode);
+
 const SettingModel: SettingModelType = {
   namespace: 'settings',
-  state: defaultSettings,
+  state: initialSettings,
   reducers: {
-    changeSetting(state = defaultSettings, { payload }) {
-      const { colorWeak, contentWidth } = payload;
+    changeSetting(state = initialSettings, { payload }) {
+      const { colorWeak, contentWidth, darkMode } = payload;
 
       if (state.contentWidth !== contentWidth && window.dispatchEvent) {
         window.dispatchEvent(new Event('resize'));
       }
       updateColorWeak(!!colorWeak);
+      if (typeof darkMode === 'boolean') {
+        applyDarkMode(darkMode);
+      }
       return {
         ...state,
         ...payload,

--- a/src/AgileConfig.Server.UI/react-ui-antd/src/pages/Configs/comps/JsonEditor.tsx
+++ b/src/AgileConfig.Server.UI/react-ui-antd/src/pages/Configs/comps/JsonEditor.tsx
@@ -11,6 +11,7 @@ loader.config({ paths: { vs: 'monaco-editor/min/vs' } });
 export type JsonEditorProps = {
   appId: string;
   appName: string;
+  darkMode: boolean;
   ModalVisible: boolean;
   env: string;
   onCancel: () => void;
@@ -115,6 +116,7 @@ const JsonEditor: React.FC<JsonEditorProps> = (props) => {
         defaultLanguage="json"
         defaultValue=""
         value={json}
+        theme={props.darkMode ? 'vs-dark' : 'vs'}
         options={{ minimap: { enabled: false } }}
         beforeMount={(monaco) => {
           monaco.languages.json.jsonDefaults.setDiagnosticsOptions({

--- a/src/AgileConfig.Server.UI/react-ui-antd/src/pages/Configs/comps/TextEditor.tsx
+++ b/src/AgileConfig.Server.UI/react-ui-antd/src/pages/Configs/comps/TextEditor.tsx
@@ -8,6 +8,7 @@ import { useIntl } from 'umi';
 export type TextEditorProps = {
   appId: string;
   appName: string;
+  darkMode: boolean;
   ModalVisible: boolean;
   env: string;
   onCancel: () => void;
@@ -133,6 +134,7 @@ const TextEditor: React.FC<TextEditorProps> = (props) => {
         defaultLanguage="text"
         defaultValue=""
         value={kvText}
+        theme={props.darkMode ? 'vs-dark' : 'vs'}
         options={{ minimap: { enabled: false } }}
         onChange={(v, e) => {
           setkvText(v);

--- a/src/AgileConfig.Server.UI/react-ui-antd/src/pages/Configs/index.tsx
+++ b/src/AgileConfig.Server.UI/react-ui-antd/src/pages/Configs/index.tsx
@@ -11,7 +11,7 @@ import Text from 'antd/lib/typography/Text';
 import moment from 'moment';
 import styles from './index.less';
 import JsonImport from './comps/JsonImport';
-import { getIntl, getLocale, useIntl } from 'umi';
+import { connect, getIntl, getLocale, useIntl } from 'umi';
 import { checkUserPermission } from '@/components/Authorized/AuthorizedElement';
 import { RequireFunction } from '@/utils/permission';
 import functionKeys from '@/models/functionKeys';
@@ -22,6 +22,7 @@ import JsonEditor from './comps/JsonEditor';
 import TextEditor from './comps/TextEditor';
 import { getEnvList } from '@/utils/system';
 import { saveVisitApp } from '@/utils/latestVisitApps';
+import type { ConnectState } from '@/models/connect';
 
 const { TextArea } = Input;
 const { confirm } = Modal;
@@ -200,7 +201,18 @@ const handleExportJson = async (appId: string, env:string) => {
   }
 }
 
-const configs: React.FC = (props: any) => {
+type ConfigsProps = {
+  darkMode: boolean;
+  match: {
+    params: {
+      app_id: string;
+      app_name: string;
+    };
+  };
+};
+
+const configs: React.FC<ConfigsProps> = (props) => {
+  const { darkMode } = props;
   const appId = props.match.params.app_id;
   const appName = props.match.params.app_name;
   useEffect(()=>{
@@ -815,6 +827,7 @@ const configs: React.FC = (props: any) => {
         <JsonEditor 
         appId={appId}
         appName={appName}
+        darkMode={darkMode}
         env={currentEnv}
         ModalVisible={jsonEditorVisible}
         onCancel={
@@ -838,6 +851,7 @@ const configs: React.FC = (props: any) => {
         <TextEditor 
         appId={appId}
         appName={appName}
+        darkMode={darkMode}
         env={currentEnv}
         ModalVisible={textEditorVisible}
         onCancel={
@@ -898,4 +912,6 @@ const configs: React.FC = (props: any) => {
     </PageContainer>
   );
 }
-export default configs;
+export default connect(({ settings }: ConnectState) => ({
+  darkMode: !!settings.darkMode,
+}))(configs);

--- a/src/AgileConfig.Server.UI/react-ui-antd/src/pages/Home/index.less
+++ b/src/AgileConfig.Server.UI/react-ui-antd/src/pages/Home/index.less
@@ -38,3 +38,7 @@
     padding: 20px 20px;
     margin-bottom: 20px;
 }
+
+:global(html.dark-mode) .panel {
+    background-color: #1f1f1f;
+}

--- a/src/AgileConfig.Server.UI/react-ui-antd/src/utils/theme.ts
+++ b/src/AgileConfig.Server.UI/react-ui-antd/src/utils/theme.ts
@@ -1,0 +1,27 @@
+const themeStorageKey = 'agileconfig.theme';
+
+export const getStoredDarkMode = (): boolean => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  try {
+    return window.localStorage.getItem(themeStorageKey) === 'dark';
+  } catch {
+    return false;
+  }
+};
+
+export const applyDarkMode = (darkMode: boolean): void => {
+  if (typeof document !== 'undefined') {
+    document.documentElement.classList.toggle('dark-mode', darkMode);
+  }
+
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.setItem(themeStorageKey, darkMode ? 'dark' : 'light');
+    } catch {
+      // Storage can be unavailable in private or restricted browsing contexts.
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- add a persisted dark-mode toggle to the admin UI
- apply dark styling to layout, forms, tables, overlays, and Monaco editors
- bump the server version to 1.12.8

## Validation
- git diff --check
- targeted Stylelint passed
- TypeScript check remains blocked by existing repository errors
- Umi production build is incompatible with local Node 22/Webpack 4