### PR TITLE
Add v2 REST API and application service layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@
 [Dd]ebugPublic/
 [Rr]elease/
 [Rr]eleases/
+!src/AgileConfig.Server.Application/Releases/
+!src/AgileConfig.Server.Application/Releases/**
 x64/
 x86/
 bld/

--- a/AgileConfig.sln
+++ b/AgileConfig.sln
@@ -56,6 +56,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgileConfig.Server.Event", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgileConfig.Server.EventHandler", "src\AgileConfig.Server.EventHandler\AgileConfig.Server.EventHandler.csproj", "{899F5AAE-2C6F-4F0A-9358-6F5C7D0412DC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgileConfig.Server.Application", "src\AgileConfig.Server.Application\AgileConfig.Server.Application.csproj", "{CA724F53-FA58-44CC-B0E7-5FD05CF5E63E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgileConfig.Server.ApplicationTests", "test\AgileConfig.Server.ApplicationTests\AgileConfig.Server.ApplicationTests.csproj", "{0AF33559-2F97-4F77-B8E4-859B6A341BA8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -142,6 +146,14 @@ Global
 		{899F5AAE-2C6F-4F0A-9358-6F5C7D0412DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{899F5AAE-2C6F-4F0A-9358-6F5C7D0412DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{899F5AAE-2C6F-4F0A-9358-6F5C7D0412DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CA724F53-FA58-44CC-B0E7-5FD05CF5E63E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CA724F53-FA58-44CC-B0E7-5FD05CF5E63E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CA724F53-FA58-44CC-B0E7-5FD05CF5E63E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CA724F53-FA58-44CC-B0E7-5FD05CF5E63E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0AF33559-2F97-4F77-B8E4-859B6A341BA8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0AF33559-2F97-4F77-B8E4-859B6A341BA8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0AF33559-2F97-4F77-B8E4-859B6A341BA8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0AF33559-2F97-4F77-B8E4-859B6A341BA8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -167,6 +179,8 @@ Global
 		{AC7E4D24-D5E8-4E30-BFB0-5DDC581CB0C2} = {F277EC27-8C0E-4490-9645-F5F3244F9246}
 		{C1138EE0-0C28-4BDE-82CD-CCE621C21BD0} = {1D2FD643-CB85-40F9-BC8A-CE4A39E9F43E}
 		{899F5AAE-2C6F-4F0A-9358-6F5C7D0412DC} = {1D2FD643-CB85-40F9-BC8A-CE4A39E9F43E}
+		{CA724F53-FA58-44CC-B0E7-5FD05CF5E63E} = {1D2FD643-CB85-40F9-BC8A-CE4A39E9F43E}
+		{0AF33559-2F97-4F77-B8E4-859B6A341BA8} = {F277EC27-8C0E-4490-9645-F5F3244F9246}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7F10DB58-5B6F-4EAC-994F-14E8046B306F}

--- a/docs/api-v2.md
+++ b/docs/api-v2.md
@@ -1,0 +1,58 @@
+# AgileConfig REST API v2
+
+API v2 is available below `/api/v2`. It is additive: the existing `/api/*` endpoints remain available and keep
+their original contracts.
+
+## Authentication
+
+- Administrative resources use HTTP Basic authentication with an AgileConfig administrator username and password.
+- `published-configurations` uses the application ID and secret as the Basic authentication username and password.
+- Service registration and heartbeat endpoints remain unauthenticated for compatibility with the existing service
+  registry protocol. Service instance queries and deletion require administrator Basic authentication.
+
+Administrative actions continue to enforce the same AgileConfig function permissions as their v1 equivalents.
+
+## Resources
+
+| Method | Path | Result |
+| --- | --- | --- |
+| `GET` | `/api/v2/applications` | List applications |
+| `POST` | `/api/v2/applications` | Create an application |
+| `GET` | `/api/v2/applications/{applicationId}` | Get an application |
+| `PUT` | `/api/v2/applications/{applicationId}` | Replace an application |
+| `DELETE` | `/api/v2/applications/{applicationId}` | Delete an application |
+| `GET` | `/api/v2/applications/{applicationId}/environments/{environment}/configurations` | List editable configurations |
+| `POST` | `/api/v2/applications/{applicationId}/environments/{environment}/configurations` | Create a configuration |
+| `GET` | `/api/v2/applications/{applicationId}/environments/{environment}/configurations/{configurationId}` | Get a configuration |
+| `PUT` | `/api/v2/applications/{applicationId}/environments/{environment}/configurations/{configurationId}` | Replace a configuration |
+| `DELETE` | `/api/v2/applications/{applicationId}/environments/{environment}/configurations/{configurationId}` | Mark a configuration for deletion |
+| `GET` | `/api/v2/applications/{applicationId}/environments/{environment}/published-configurations` | Pull the effective published configuration |
+| `GET` | `/api/v2/applications/{applicationId}/environments/{environment}/releases` | List releases |
+| `POST` | `/api/v2/applications/{applicationId}/environments/{environment}/releases` | Publish pending changes |
+| `GET` | `/api/v2/applications/{applicationId}/environments/{environment}/releases/{releaseId}` | Get a release |
+| `POST` | `/api/v2/applications/{applicationId}/environments/{environment}/releases/rollbacks` | Roll back to a release |
+| `GET` | `/api/v2/nodes` | List cluster nodes |
+| `POST` | `/api/v2/nodes` | Add a cluster node |
+| `GET` | `/api/v2/nodes/{nodeId}` | Get a cluster node |
+| `DELETE` | `/api/v2/nodes/{nodeId}` | Delete a cluster node |
+| `GET` | `/api/v2/service-instances?status={Healthy\|Unhealthy}` | List or filter service instances |
+| `POST` | `/api/v2/service-instances` | Register or refresh a service instance |
+| `GET` | `/api/v2/service-instances/{serviceInstanceId}` | Get a service instance |
+| `DELETE` | `/api/v2/service-instances/{serviceInstanceId}` | Unregister a service instance |
+| `PUT` | `/api/v2/service-instances/{serviceInstanceId}/heartbeat` | Record a heartbeat |
+
+Node IDs are opaque URL-safe values returned by the API. Clients should not construct them from node addresses.
+
+## HTTP semantics
+
+- Creation returns `201 Created`, the created representation, and a `Location` header. Re-registering an existing
+  service instance returns `200 OK` because the existing resource is updated.
+- Successful deletion and rollback return `204 No Content`.
+- Missing resources return `404 Not Found`; identifier/key conflicts return `409 Conflict`.
+- Validation and domain errors use `application/problem+json` (`ProblemDetails`). Authentication and permission
+  failures retain the server's existing `403 Forbidden` behavior.
+- Published configuration responses include `ETag` and `X-Publish-Timeline-Id`. Sending the ETag in
+  `If-None-Match` returns `304 Not Modified` when the published version has not changed.
+
+Deleting an already published configuration removes it from the v2 editable resource view immediately, while the
+previous published value remains available to application clients until the pending deletion is released.

--- a/docs/application-layer.md
+++ b/docs/application-layer.md
@@ -1,0 +1,50 @@
+# Application layer
+
+`AgileConfig.Server.Application` contains transport-independent application use cases. Both the legacy MVC controllers and the REST API controllers call this layer so that business behavior is implemented once.
+
+## Dependency direction
+
+```text
+Apisite controllers
+        |
+        v
+AgileConfig.Server.Application
+        |
+        v
+AgileConfig.Server.IService / domain events
+        |
+        v
+repositories
+```
+
+The Application project must not reference ASP.NET Core MVC, Apisite request models, controllers, or HTTP result types.
+
+## Responsibilities
+
+Controllers own:
+
+- authentication and authorization filters;
+- HTTP request and response models;
+- status codes, headers, routes, and `ProblemDetails`;
+- compatibility mapping for legacy response envelopes.
+
+Application services own:
+
+- use-case validation and conflict detection;
+- entity creation and state transitions;
+- orchestration of the existing business services;
+- current-user audit values and timestamps;
+- domain-event publication and other required side effects.
+
+The existing services in `AgileConfig.Server.IService` and `AgileConfig.Server.Service` continue to own persistence-oriented operations, queries, caches, and lower-level domain behavior.
+
+Expected business failures are returned as `ApplicationResult` values. Application services do not return `IActionResult`, select HTTP status codes, or format user-facing HTTP payloads.
+
+## Compatibility
+
+Legacy and v2 controllers deliberately map the same application result differently:
+
+- legacy controllers preserve their existing `{ success, message, data }` envelopes and status-code behavior;
+- v2 controllers use resource responses, standard status codes, and `ProblemDetails`.
+
+Any application-service migration must keep integration coverage for both contracts.

--- a/src/AgileConfig.Server.Apisite/AgileConfig.Server.Apisite.csproj
+++ b/src/AgileConfig.Server.Apisite/AgileConfig.Server.Apisite.csproj
@@ -48,6 +48,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<ProjectReference Include="..\AgileConfig.Server.Application\AgileConfig.Server.Application.csproj" />
 		<ProjectReference Include="..\AgileConfig.Server.Common\AgileConfig.Server.Common.csproj" />
 		<ProjectReference Include="..\AgileConfig.Server.Data.Abstraction\AgileConfig.Server.Data.Abstraction.csproj" />
 		<ProjectReference Include="..\AgileConfig.Server.Data.Repository.Freesql\AgileConfig.Server.Data.Repository.Freesql.csproj" />

--- a/src/AgileConfig.Server.Apisite/Application/AppsettingsPreviewModeAccessor.cs
+++ b/src/AgileConfig.Server.Apisite/Application/AppsettingsPreviewModeAccessor.cs
@@ -1,0 +1,9 @@
+using AgileConfig.Server.Application;
+using AgileConfig.Server.Common;
+
+namespace AgileConfig.Server.Apisite.Application;
+
+public sealed class AppsettingsPreviewModeAccessor : IPreviewModeAccessor
+{
+    public bool IsPreviewMode => Appsettings.IsPreviewMode;
+}

--- a/src/AgileConfig.Server.Apisite/Application/HttpCurrentUserAccessor.cs
+++ b/src/AgileConfig.Server.Apisite/Application/HttpCurrentUserAccessor.cs
@@ -1,0 +1,51 @@
+using System.Linq;
+using System.Threading.Tasks;
+using AgileConfig.Server.Application;
+using AgileConfig.Server.Common;
+using AgileConfig.Server.Data.Entity;
+using AgileConfig.Server.IService;
+using Microsoft.AspNetCore.Http;
+
+namespace AgileConfig.Server.Apisite.Application;
+
+public sealed class HttpCurrentUserAccessor : ICurrentUserAccessor
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IUserService _userService;
+
+    public HttpCurrentUserAccessor(IHttpContextAccessor httpContextAccessor, IUserService userService)
+    {
+        _httpContextAccessor = httpContextAccessor;
+        _userService = userService;
+    }
+
+    public string UserName
+    {
+        get
+        {
+            var context = _httpContextAccessor.HttpContext;
+            if (context == null) return null;
+
+            var userName = context.GetUserNameFromClaim();
+            return string.IsNullOrEmpty(userName)
+                ? context.Request.GetUserNamePasswordFromBasicAuthorization().Item1
+                : userName;
+        }
+    }
+
+    public async Task<string> GetUserIdAsync()
+    {
+        var context = _httpContextAccessor.HttpContext;
+        if (context == null) return null;
+
+        var userId = context.GetUserIdFromClaim();
+        if (!string.IsNullOrEmpty(userId)) return userId;
+
+        var userName = context.Request.GetUserNamePasswordFromBasicAuthorization().Item1;
+        if (string.IsNullOrEmpty(userName)) return null;
+
+        var user = (await _userService.GetUsersByNameAsync(userName))
+            .FirstOrDefault(x => x.Status == UserStatus.Normal);
+        return user?.Id;
+    }
+}

--- a/src/AgileConfig.Server.Apisite/Controllers/AppController.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/AppController.cs
@@ -3,15 +3,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using AgileConfig.Server.Application;
 using AgileConfig.Server.Apisite.Filters;
 using AgileConfig.Server.Apisite.Models;
 using AgileConfig.Server.Apisite.Models.Mapping;
 using AgileConfig.Server.Apisite.Utilites;
 using AgileConfig.Server.Common;
-using AgileConfig.Server.Common.EventBus;
 using AgileConfig.Server.Common.Resources;
 using AgileConfig.Server.Data.Entity;
-using AgileConfig.Server.Event;
 using AgileConfig.Server.IService;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -26,21 +25,21 @@ public class AppController : Controller
 {
     private readonly IAppService _appService;
     private readonly IConfigService _configService;
+    private readonly IApplicationManagementService _applicationManagementService;
     private readonly ISettingService _settingService;
-    private readonly ITinyEventBus _tinyEventBus;
     private readonly IUserService _userService;
 
     public AppController(IAppService appService,
         IUserService userService,
         IConfigService configService,
         ISettingService settingService,
-        ITinyEventBus tinyEventBus)
+        IApplicationManagementService applicationManagementService)
     {
         _userService = userService;
         _configService = configService;
         _settingService = settingService;
-        _tinyEventBus = tinyEventBus;
         _appService = appService;
+        _applicationManagementService = applicationManagementService;
     }
 
     [TypeFilter(typeof(PermissionCheckAttribute),
@@ -142,41 +141,27 @@ public class AppController : Controller
     {
         ArgumentNullException.ThrowIfNull(model);
 
-        var oldApp = await _appService.GetAsync(model.Id);
-        if (oldApp != null)
+        var result = await _applicationManagementService.CreateAsync(new CreateApplicationCommand(
+            model.Id,
+            model.Name,
+            model.Group,
+            model.Secret,
+            model.Enabled,
+            model.Inheritanced,
+            model.inheritancedApps));
+
+        if (result.Error == ApplicationError.Conflict)
             return Json(new
             {
                 success = false,
                 message = Messages.AppIdExists
             });
 
-        var app = model.ToApp();
-        app.CreateTime = DateTime.Now;
-        var creatorId = await this.GetCurrentUserId(_userService);
-        if (!string.IsNullOrWhiteSpace(creatorId)) app.Creator = creatorId;
-
-        var inheritanceApps = new List<AppInheritanced>();
-        if (!model.Inheritanced && model.inheritancedApps != null)
-        {
-            var sort = 0;
-            model.inheritancedApps.ForEach(appId =>
-            {
-                inheritanceApps.Add(new AppInheritanced
-                {
-                    Id = Guid.NewGuid().ToString("N"),
-                    AppId = app.Id,
-                    InheritancedAppId = appId,
-                    Sort = sort++
-                });
-            });
-        }
-
-        var result = await _appService.AddAsync(app, inheritanceApps);
         return Json(new
         {
-            data = app,
-            success = result,
-            message = !result ? Messages.CreateAppFailed : ""
+            data = result.Value,
+            success = result.Succeeded,
+            message = !result.Succeeded ? Messages.CreateAppFailed : ""
         });
     }
 
@@ -186,44 +171,33 @@ public class AppController : Controller
     {
         ArgumentNullException.ThrowIfNull(model);
 
-        var app = await _appService.GetAsync(model.Id);
-        if (app == null)
+        var result = await _applicationManagementService.UpdateAsync(new UpdateApplicationCommand(
+            model.Id,
+            model.Name,
+            model.Group,
+            model.Secret,
+            model.Enabled,
+            model.Inheritanced,
+            model.inheritancedApps));
+
+        if (result.Error == ApplicationError.NotFound)
             return Json(new
             {
                 success = false,
                 message = Messages.AppNotFound
             });
 
-        if (Appsettings.IsPreviewMode && app.Name == "test_app")
+        if (result.Error == ApplicationError.ValidationFailed)
             return Json(new
             {
                 success = false,
                 message = Messages.DemoModeNoTestAppEdit
             });
 
-        app = model.ToApp(app);
-        app.UpdateTime = DateTime.Now;
-        var inheritanceApps = new List<AppInheritanced>();
-        if (!model.Inheritanced && model.inheritancedApps != null)
-        {
-            var sort = 0;
-            model.inheritancedApps.ForEach(appId =>
-            {
-                inheritanceApps.Add(new AppInheritanced
-                {
-                    Id = Guid.NewGuid().ToString("N"),
-                    AppId = app.Id,
-                    InheritancedAppId = appId,
-                    Sort = sort++
-                });
-            });
-        }
-
-        var result = await _appService.UpdateAsync(app, inheritanceApps);
         return Json(new
         {
-            success = result,
-            message = !result ? Messages.UpdateAppFailed : ""
+            success = result.Succeeded,
+            message = !result.Succeeded ? Messages.UpdateAppFailed : ""
         });
     }
 
@@ -283,22 +257,18 @@ public class AppController : Controller
     {
         ArgumentException.ThrowIfNullOrEmpty(id);
 
-        var app = await _appService.GetAsync(id);
-        if (app == null)
+        var result = await _applicationManagementService.DeleteAsync(new DeleteApplicationCommand(id));
+        if (result.Error == ApplicationError.NotFound)
             return NotFound(new
             {
                 success = false,
                 message = Messages.AppNotFound
             });
 
-        var result = await _appService.DeleteAsync(app);
-
-        if (result) _tinyEventBus.Fire(new DeleteAppSuccessful(app, this.GetCurrentUserName()));
-
         return Json(new
         {
-            success = result,
-            message = !result ? Messages.UpdateAppFailed : ""
+            success = result.Succeeded,
+            message = !result.Succeeded ? Messages.UpdateAppFailed : ""
         });
     }
 

--- a/src/AgileConfig.Server.Apisite/Controllers/ConfigController.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/ConfigController.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using AgileConfig.Server.Application;
+using AgileConfig.Server.Application.Configurations;
+using AgileConfig.Server.Application.Releases;
 using AgileConfig.Server.Apisite.Filters;
 using AgileConfig.Server.Apisite.Models;
 using AgileConfig.Server.Apisite.Utilites;
@@ -24,20 +27,23 @@ public class ConfigController : Controller
 {
     private readonly IAppService _appService;
     private readonly IConfigService _configService;
+    private readonly IConfigurationManagementService _configurationManagementService;
+    private readonly IReleaseManagementService _releaseManagementService;
     private readonly ITinyEventBus _tinyEventBus;
-    private readonly IUserService _userService;
 
     public ConfigController(
         IConfigService configService,
         IAppService appService,
-        IUserService userService,
-        ITinyEventBus tinyEventBus
+        ITinyEventBus tinyEventBus,
+        IConfigurationManagementService configurationManagementService,
+        IReleaseManagementService releaseManagementService
     )
     {
         _configService = configService;
         _appService = appService;
-        _userService = userService;
         _tinyEventBus = tinyEventBus;
+        _configurationManagementService = configurationManagementService;
+        _releaseManagementService = releaseManagementService;
     }
 
     [TypeFilter(typeof(PermissionCheckAttribute), Arguments = new object[] { Functions.Config_Add })]
@@ -46,45 +52,34 @@ public class ConfigController : Controller
     {
         ArgumentNullException.ThrowIfNull(model);
 
-        var app = await _appService.GetAsync(model.AppId);
-        if (app == null)
-            return Json(new
+        var result = await _configurationManagementService.CreateAsync(new CreateConfigurationCommand(
+            model.Id,
+            model.AppId,
+            model.Group,
+            model.Key,
+            model.Value,
+            model.Description,
+            env.Value));
+
+        if (!result.Succeeded)
+        {
+            var message = result.Error switch
             {
-                success = false,
-                message = Messages.AppNotExists(model.AppId)
-            });
+                ApplicationError.NotFound => Messages.AppNotExists(model.AppId),
+                ApplicationError.Conflict => Messages.ConfigExists,
+                _ => Messages.CreateConfigFailed
+            };
 
-        var oldConfig = await _configService.GetByAppIdKeyEnv(model.AppId, model.Group, model.Key, env.Value);
-        if (oldConfig != null)
-            return Json(new
-            {
-                success = false,
-                message = Messages.ConfigExists
-            });
-
-        var config = new Config();
-        config.Id = string.IsNullOrEmpty(model.Id) ? Guid.NewGuid().ToString("N") : model.Id;
-        config.Key = model.Key;
-        config.AppId = model.AppId;
-        config.Description = model.Description;
-        config.Value = model.Value;
-        config.Group = model.Group;
-        config.Status = ConfigStatus.Enabled;
-        config.CreateTime = DateTime.Now;
-        config.UpdateTime = null;
-        config.OnlineStatus = OnlineStatus.WaitPublish;
-        config.EditStatus = EditStatus.Add;
-        config.Env = env.Value;
-
-        var result = await _configService.AddAsync(config, env.Value);
-
-        if (result) _tinyEventBus.Fire(new AddConfigSuccessful(config, this.GetCurrentUserName()));
+            return result.Value == null
+                ? Json(new { success = false, message })
+                : Json(new { success = false, message, data = result.Value });
+        }
 
         return Json(new
         {
-            success = result,
-            message = !result ? Messages.CreateConfigFailed : "",
-            data = config
+            success = true,
+            message = "",
+            data = result.Value
         });
     }
 
@@ -153,81 +148,35 @@ public class ConfigController : Controller
     {
         if (model == null) throw new ArgumentNullException("model");
 
-        var config = await _configService.GetAsync(model.Id, env.Value);
-        if (config == null)
+        var result = await _configurationManagementService.UpdateAsync(new UpdateConfigurationCommand(
+            model.Id,
+            model.AppId,
+            model.Group,
+            model.Key,
+            model.Value,
+            model.Description,
+            env.Value));
+
+        if (!result.Succeeded)
             return Json(new
             {
                 success = false,
-                message = Messages.ConfigNotFound
-            });
-
-        var app = await _configService.GetByAppIdAsync(model.AppId, env.Value);
-        if (!app.Any())
-            return Json(new
-            {
-                success = false,
-                message = Messages.AppNotExists(model.AppId)
-            });
-
-        var oldConfig = new Config
-        {
-            Key = config.Key,
-            Group = config.Group,
-            Value = config.Value
-        };
-        if (config.Group != model.Group || config.Key != model.Key)
-        {
-            var anotherConfig = await _configService.GetByAppIdKeyEnv(model.AppId, model.Group, model.Key, env.Value);
-            if (anotherConfig != null)
-                return Json(new
+                message = result.Error switch
                 {
-                    success = false,
-                    message = Messages.ConfigKeyExists
-                });
-        }
-
-        config.AppId = model.AppId;
-        config.Description = model.Description;
-        config.Key = model.Key;
-        config.Value = model.Value;
-        config.Group = model.Group;
-        config.UpdateTime = DateTime.Now;
-        config.Env = env.Value;
-
-        if (!IsOnlyUpdateDescription(config, oldConfig))
-        {
-            var isPublished = await _configService.IsPublishedAsync(config.Id, env.Value);
-            if (isPublished)
-                // When an already published configuration is modified, mark it as edited.
-                config.EditStatus = EditStatus.Edit;
-            else
-                // If it has never been published, keep the status as added.
-                config.EditStatus = EditStatus.Add;
-
-            config.OnlineStatus = OnlineStatus.WaitPublish;
-        }
-
-        var result = await _configService.UpdateAsync(config, env.Value);
-
-        if (result) _tinyEventBus.Fire(new EditConfigSuccessful(config, this.GetCurrentUserName()));
+                    ApplicationError.NotFound =>
+                        (await _configService.GetAsync(model.Id, env.Value)) == null
+                            ? Messages.ConfigNotFound
+                            : Messages.AppNotExists(model.AppId),
+                    ApplicationError.Conflict => Messages.ConfigKeyExists,
+                    _ => "修改配置失败，请查看错误日志。"
+                }
+            });
 
         return Json(new
         {
-            success = result,
-            message = !result ? "修改配置失败，请查看错误日志。" : ""
+            success = true,
+            message = ""
         });
-    }
-
-    /// <summary>
-    ///     Determine whether only the description field changed.
-    /// </summary>
-    /// <param name="newConfig">Configuration submitted by the client.</param>
-    /// <param name="oldConfig">Existing configuration stored in the database.</param>
-    /// <returns>True when only the description differs.</returns>
-    private bool IsOnlyUpdateDescription(Config newConfig, Config oldConfig)
-    {
-        return newConfig.Key == oldConfig.Key && newConfig.Group == oldConfig.Group &&
-               newConfig.Value == oldConfig.Value;
     }
 
     [HttpGet]
@@ -321,29 +270,22 @@ public class ConfigController : Controller
     {
         if (string.IsNullOrEmpty(id)) throw new ArgumentNullException("id");
 
-        var config = await _configService.GetAsync(id, env.Value);
-        if (config == null)
+        var result = await _configurationManagementService.DeleteAsync(
+            new DeleteConfigurationCommand(id, env.Value));
+
+        if (!result.Succeeded)
             return Json(new
             {
                 success = false,
-                message = "未找到对应的配置项。"
+                message = result.Error == ApplicationError.NotFound
+                    ? "未找到对应的配置项。"
+                    : "删除配置失败，请查看错误日志"
             });
-
-        config.EditStatus = EditStatus.Deleted;
-        config.OnlineStatus = OnlineStatus.WaitPublish;
-
-        var isPublished = await _configService.IsPublishedAsync(config.Id, env.Value);
-        if (!isPublished)
-            // If it has never been published, remove it directly.
-            config.Status = ConfigStatus.Deleted;
-
-        var result = await _configService.UpdateAsync(config, env.Value);
-        if (result) _tinyEventBus.Fire(new DeleteConfigSuccessful(config, this.GetCurrentUserName()));
 
         return Json(new
         {
-            success = result,
-            message = !result ? "删除配置失败，请查看错误日志" : ""
+            success = true,
+            message = ""
         });
     }
 
@@ -396,18 +338,13 @@ public class ConfigController : Controller
     {
         if (string.IsNullOrEmpty(publishTimelineId)) throw new ArgumentNullException("publishTimelineId");
 
-        var result = await _configService.RollbackAsync(publishTimelineId, env.Value);
-
-        if (result)
-        {
-            var node = await _configService.GetPublishTimeLineNodeAsync(publishTimelineId, env.Value);
-            _tinyEventBus.Fire(new RollbackConfigSuccessful(node, this.GetCurrentUserName()));
-        }
+        var result = await _releaseManagementService.RollbackAsync(
+            new RollbackConfigurationCommand(publishTimelineId, env.Value));
 
         return Json(new
         {
-            success = result,
-            message = !result ? "回滚失败，请查看错误日志。" : ""
+            success = result.Succeeded,
+            message = !result.Succeeded ? "回滚失败，请查看错误日志。" : ""
         });
     }
 
@@ -453,20 +390,16 @@ public class ConfigController : Controller
 
         if (string.IsNullOrEmpty(model.AppId)) throw new ArgumentNullException("appId");
 
-        var appId = model.AppId;
-        var userId = await this.GetCurrentUserId(_userService);
-        var ret = await _configService.Publish(appId, model.Ids, model.Log, userId, env.Value);
-
-        if (ret.result)
-        {
-            var timelineNode = await _configService.GetPublishTimeLineNodeAsync(ret.publishTimelineId, env.Value);
-            _tinyEventBus.Fire(new PublishConfigSuccessful(timelineNode, this.GetCurrentUserName()));
-        }
+        var result = await _releaseManagementService.PublishAsync(new PublishConfigurationsCommand(
+            model.AppId,
+            model.Ids,
+            model.Log,
+            env.Value));
 
         return Json(new
         {
-            success = ret.result,
-            message = !ret.result ? "上线配置失败，请查看错误日志" : ""
+            success = result.Succeeded,
+            message = !result.Succeeded ? "上线配置失败，请查看错误日志" : ""
         });
     }
 

--- a/src/AgileConfig.Server.Apisite/Controllers/ServerNodeController.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/ServerNodeController.cs
@@ -1,13 +1,10 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using AgileConfig.Server.Application;
 using AgileConfig.Server.Apisite.Filters;
 using AgileConfig.Server.Apisite.Models;
-using AgileConfig.Server.Apisite.Utilites;
-using AgileConfig.Server.Common.EventBus;
 using AgileConfig.Server.Common.Resources;
-using AgileConfig.Server.Data.Entity;
-using AgileConfig.Server.Event;
 using AgileConfig.Server.IService;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -18,21 +15,11 @@ namespace AgileConfig.Server.Apisite.Controllers;
 [ModelVaildate]
 public class ServerNodeController : Controller
 {
-    private readonly IRemoteServerNodeProxy _remoteServerNodeProxy;
-    private readonly IServerNodeService _serverNodeService;
-    private readonly ISysLogService _sysLogService;
-    private readonly ITinyEventBus _tinyEventBus;
+    private readonly INodeManagementService _nodeManagementService;
 
-    public ServerNodeController(IServerNodeService serverNodeService,
-        ISysLogService sysLogService,
-        IRemoteServerNodeProxy remoteServerNodeProxy,
-        ITinyEventBus tinyEventBus
-    )
+    public ServerNodeController(INodeManagementService nodeManagementService)
     {
-        _serverNodeService = serverNodeService;
-        _sysLogService = sysLogService;
-        _remoteServerNodeProxy = remoteServerNodeProxy;
-        _tinyEventBus = tinyEventBus;
+        _nodeManagementService = nodeManagementService;
     }
 
     [TypeFilter(typeof(PermissionCheckAttribute), Arguments = new object[] { Functions.Node_Add })]
@@ -40,33 +27,20 @@ public class ServerNodeController : Controller
     public async Task<IActionResult> Add([FromBody] ServerNodeVM model)
     {
         if (model == null) throw new ArgumentNullException("model");
-        model.Address = model.Address.TrimEnd('/');
-        var oldNode = await _serverNodeService.GetAsync(model.Address);
-        if (oldNode != null)
+
+        var result = await _nodeManagementService.CreateAsync(new CreateNodeCommand(model.Address, model.Remark));
+        if (!result.Succeeded && result.Error == ApplicationError.Conflict)
             return Json(new
             {
                 success = false,
                 message = Messages.NodeAlreadyExists
             });
 
-        var node = new ServerNode();
-        node.Id = model.Address.TrimEnd('/');
-        node.Remark = model.Remark;
-        node.Status = NodeStatus.Offline;
-        node.CreateTime = DateTime.Now;
-
-        var result = await _serverNodeService.AddAsync(node);
-        if (result)
-        {
-            _tinyEventBus.Fire(new AddNodeSuccessful(node, this.GetCurrentUserName()));
-            await _remoteServerNodeProxy.TestEchoAsync(node.Id);
-        }
-
         return Json(new
         {
-            data = node,
-            success = result,
-            message = !result ? Messages.AddNodeFailed : ""
+            data = result.Value,
+            success = result.Succeeded,
+            message = !result.Succeeded ? Messages.AddNodeFailed : ""
         });
     }
 
@@ -74,35 +48,20 @@ public class ServerNodeController : Controller
     [HttpPost]
     public async Task<IActionResult> Delete([FromBody] ServerNodeVM model)
     {
-        if (Appsettings.IsPreviewMode)
-            return Json(new
-            {
-                success = false,
-                message = Messages.DemoModeNoNodeDelete
-            });
         if (model == null) throw new ArgumentNullException("model");
 
-        var node = await _serverNodeService.GetAsync(model.Address);
-        if (node == null)
-            return Json(new
-            {
-                success = false,
-                message = Messages.NodeNotFound
-            });
-
-        var result = await _serverNodeService.DeleteAsync(node);
-        if (result) _tinyEventBus.Fire(new DeleteNodeSuccessful(node, this.GetCurrentUserName()));
+        var result = await _nodeManagementService.DeleteAsync(model.Address);
         return Json(new
         {
-            success = result,
-            message = !result ? Messages.DeleteNodeFailed : ""
+            success = result.Succeeded,
+            message = !result.Succeeded ? GetDeleteErrorMessage(result.Error) : ""
         });
     }
 
     [HttpGet]
     public async Task<IActionResult> All()
     {
-        var nodes = await _serverNodeService.GetAllNodesAsync();
+        var nodes = await _nodeManagementService.GetAllAsync();
 
         var vms = nodes.OrderBy(x => x.CreateTime).Select(x =>
         {
@@ -120,5 +79,15 @@ public class ServerNodeController : Controller
             success = true,
             data = vms
         });
+    }
+
+    private static string GetDeleteErrorMessage(ApplicationError error)
+    {
+        return error switch
+        {
+            ApplicationError.Forbidden => Messages.DemoModeNoNodeDelete,
+            ApplicationError.NotFound => Messages.NodeNotFound,
+            _ => Messages.DeleteNodeFailed
+        };
     }
 }

--- a/src/AgileConfig.Server.Apisite/Controllers/ServiceController.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/ServiceController.cs
@@ -2,12 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using AgileConfig.Server.Application;
 using AgileConfig.Server.Apisite.Filters;
 using AgileConfig.Server.Apisite.Models;
-using AgileConfig.Server.Common.EventBus;
 using AgileConfig.Server.Common.Resources;
 using AgileConfig.Server.Data.Entity;
-using AgileConfig.Server.Event;
 using AgileConfig.Server.IService;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -18,17 +17,15 @@ namespace AgileConfig.Server.Apisite.Controllers;
 [ModelVaildate]
 public class ServiceController : Controller
 {
-    private readonly IRegisterCenterService _registerCenterService;
+    private readonly IServiceInstanceManagementService _serviceInstanceManagementService;
     private readonly IServiceInfoService _serviceInfoService;
-    private readonly ITinyEventBus _tinyEventBus;
 
-    public ServiceController(IServiceInfoService serviceInfoService,
-        IRegisterCenterService registerCenterService,
-        ITinyEventBus tinyEventBus)
+    public ServiceController(
+        IServiceInfoService serviceInfoService,
+        IServiceInstanceManagementService serviceInstanceManagementService)
     {
         _serviceInfoService = serviceInfoService;
-        _registerCenterService = registerCenterService;
-        _tinyEventBus = tinyEventBus;
+        _serviceInstanceManagementService = serviceInstanceManagementService;
     }
 
     [HttpPost]
@@ -37,26 +34,25 @@ public class ServiceController : Controller
     {
         if (model == null) throw new ArgumentNullException(nameof(model));
 
-        if (await _serviceInfoService.GetByServiceIdAsync(model.ServiceId) != null)
+        var result = await _serviceInstanceManagementService.RegisterAsync(new RegisterServiceInstanceCommand(
+            model.ServiceId,
+            model.ServiceName,
+            model.Ip,
+            model.Port,
+            model.MetaData,
+            model.CheckUrl,
+            model.AlarmUrl,
+            model.HeartBeatMode,
+            RegisterWay.Manual,
+            RejectExisting: true,
+            AcceptMissingIdentifier: true));
+
+        if (!result.Succeeded)
             return Json(new
             {
                 success = false,
-                message = Messages.ServiceAlreadyExists
+                message = result.Error == ApplicationError.Conflict ? Messages.ServiceAlreadyExists : ""
             });
-
-        var service = new ServiceInfo();
-        service.Ip = model.Ip;
-        service.Port = model.Port;
-        service.AlarmUrl = model.AlarmUrl;
-        service.CheckUrl = model.CheckUrl;
-        service.MetaData = model.MetaData;
-        service.ServiceId = model.ServiceId;
-        service.ServiceName = model.ServiceName;
-        service.RegisterWay = RegisterWay.Manual;
-        service.HeartBeatMode = model.HeartBeatMode;
-        var uniqueId = await _registerCenterService.RegisterAsync(service);
-
-        _tinyEventBus.Fire(new ServiceRegisteredEvent(uniqueId));
 
         return Json(new
         {
@@ -70,21 +66,19 @@ public class ServiceController : Controller
     {
         if (string.IsNullOrEmpty(id)) throw new ArgumentNullException("id");
 
-        var service = await _serviceInfoService.GetByUniqueIdAsync(id);
-        if (service == null)
+        var result = await _serviceInstanceManagementService.UnregisterAsync(
+            id,
+            succeedWhenRemovalFails: true);
+        if (!result.Succeeded && result.Error == ApplicationError.NotFound)
             return Json(new
             {
                 success = false,
                 message = Messages.ServiceNotFound
             });
 
-        await _registerCenterService.UnRegisterAsync(id);
-
-        _tinyEventBus.Fire(new ServiceUnRegisterEvent(service.Id));
-
         return Json(new
         {
-            success = true
+            success = result.Succeeded || result.Error == ApplicationError.OperationFailed
         });
     }
 

--- a/src/AgileConfig.Server.Apisite/Controllers/api/AppController.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/api/AppController.cs
@@ -2,13 +2,15 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using AgileConfig.Server.Application;
+using AgileConfig.Server.Application.Releases;
 using AgileConfig.Server.Apisite.Controllers.api.Models;
 using AgileConfig.Server.Apisite.Filters;
 using AgileConfig.Server.Apisite.Models;
 using AgileConfig.Server.Apisite.Models.Mapping;
+using AgileConfig.Server.Common.Resources;
 using AgileConfig.Server.IService;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Infrastructure;
 
 namespace AgileConfig.Server.Apisite.Controllers.api;
 
@@ -19,21 +21,18 @@ namespace AgileConfig.Server.Apisite.Controllers.api;
 [Route("api/[controller]")]
 public class AppController : Controller
 {
-    private readonly Controllers.AppController _appController;
     private readonly IAppService _appService;
-    private readonly Controllers.ConfigController _configController;
-    private readonly IConfigService _configService;
+    private readonly IApplicationManagementService _applicationManagementService;
+    private readonly IReleaseManagementService _releaseManagementService;
 
-    public AppController(IAppService appService,
-        IConfigService configService,
-        Controllers.AppController appController,
-        Controllers.ConfigController configController)
+    public AppController(
+        IAppService appService,
+        IApplicationManagementService applicationManagementService,
+        IReleaseManagementService releaseManagementService)
     {
         _appService = appService;
-        _configService = configService;
-
-        _appController = appController;
-        _configController = configController;
+        _applicationManagementService = applicationManagementService;
+        _releaseManagementService = releaseManagementService;
     }
 
     /// <summary>
@@ -61,23 +60,18 @@ public class AppController : Controller
         Arguments = new object[] { Functions.App_Read })]
     public async Task<ActionResult<ApiAppVM>> GetById(string id)
     {
-        var actionResult = await _appController.Get(id);
-        var status = actionResult as IStatusCodeActionResult;
-
-        var result = actionResult as JsonResult;
-        dynamic obj = result?.Value;
-
-        if (obj?.success ?? false)
+        var app = await _appService.GetAsync(id);
+        if (app == null)
         {
-            AppVM appVM = obj.data;
-            return Json(appVM.ToApiAppVM());
+            Response.StatusCode = 404;
+            return Json(new { message = Messages.AppNotFound });
         }
 
-        Response.StatusCode = status.StatusCode.Value;
-        return Json(new
-        {
-            obj?.message
-        });
+        var resource = app.ToApiAppVM();
+        resource.InheritancedApps = (await _appService.GetInheritancedAppsAsync(id))
+            .Select(x => x.Id)
+            .ToList();
+        return Json(resource);
     }
 
     /// <summary>
@@ -101,19 +95,20 @@ public class AppController : Controller
             });
         }
 
-        _appController.ControllerContext.HttpContext = HttpContext;
-
-        var result = await _appController.Add(model.ToAppVM()) as JsonResult;
-
-        dynamic obj = result?.Value;
-
-        if (obj?.success == true) return Created("/api/app/" + obj.data.Id, "");
+        var result = await _applicationManagementService.CreateAsync(new CreateApplicationCommand(
+            model.Id,
+            model.Name,
+            model.Group,
+            model.Secret,
+            model.Enabled.GetValueOrDefault(),
+            model.Inheritanced,
+            null));
+        if (result.Succeeded) return Created("/api/app/" + result.Value.Id, "");
 
         Response.StatusCode = 400;
-        return Json(new
-        {
-            obj?.message
-        });
+        return Json(new { message = result.Error == ApplicationError.Conflict
+            ? Messages.AppIdExists
+            : Messages.CreateAppFailed });
     }
 
     /// <summary>
@@ -138,21 +133,24 @@ public class AppController : Controller
             });
         }
 
-        _appController.ControllerContext.HttpContext = HttpContext;
-
         model.Id = id;
-        var actionResult = await _appController.Edit(model.ToAppVM());
-        var status = actionResult as IStatusCodeActionResult;
-        var result = actionResult as JsonResult;
+        var result = await _applicationManagementService.UpdateAsync(new UpdateApplicationCommand(
+            id,
+            model.Name,
+            model.Group,
+            model.Secret,
+            model.Enabled.GetValueOrDefault(),
+            model.Inheritanced,
+            null));
+        if (result.Succeeded) return Ok();
 
-        dynamic obj = result?.Value;
-        if (obj?.success ?? false) return Ok();
-
-        Response.StatusCode = status.StatusCode.Value;
-        return Json(new
+        Response.StatusCode = result.Error == ApplicationError.NotFound ? 404 : 400;
+        return Json(new { message = result.Error switch
         {
-            obj?.message
-        });
+            ApplicationError.NotFound => Messages.AppNotFound,
+            ApplicationError.ValidationFailed => Messages.DemoModeNoTestAppEdit,
+            _ => Messages.UpdateAppFailed
+        } });
     }
 
     /// <summary>
@@ -166,20 +164,13 @@ public class AppController : Controller
     [HttpDelete("{id}")]
     public async Task<IActionResult> Delete(string id)
     {
-        _appController.ControllerContext.HttpContext = HttpContext;
+        var result = await _applicationManagementService.DeleteAsync(new DeleteApplicationCommand(id));
+        if (result.Succeeded) return NoContent();
 
-        var actionResult = await _appController.Delete(id);
-        var status = actionResult as IStatusCodeActionResult;
-        var result = actionResult as JsonResult;
-
-        dynamic obj = result?.Value;
-        if (obj?.success ?? false) return NoContent();
-
-        Response.StatusCode = status.StatusCode.Value;
-        return Json(new
-        {
-            obj?.message
-        });
+        Response.StatusCode = result.Error == ApplicationError.NotFound ? 404 : 400;
+        return Json(new { message = result.Error == ApplicationError.NotFound
+            ? (string)null
+            : Messages.UpdateAppFailed });
     }
 
     /// <summary>
@@ -194,23 +185,12 @@ public class AppController : Controller
     [HttpPost("publish")]
     public async Task<IActionResult> Publish(string appId, EnvString env)
     {
-        _configController.ControllerContext.HttpContext = HttpContext;
+        var result = await _releaseManagementService.PublishAsync(
+            new PublishConfigurationsCommand(appId, null, null, env.Value));
+        if (result.Succeeded) return Ok();
 
-        var actionResult = await _configController.Publish(new PublishLogVM
-        {
-            AppId = appId
-        }, env);
-        var status = actionResult as IStatusCodeActionResult;
-        var result = actionResult as JsonResult;
-
-        dynamic obj = result?.Value;
-        if (obj?.success ?? false) return Ok();
-
-        Response.StatusCode = status.StatusCode.Value;
-        return Json(new
-        {
-            obj?.message
-        });
+        Response.StatusCode = result.Error == ApplicationError.NotFound ? 404 : 400;
+        return Json(new { message = "上线配置失败，请查看错误日志" });
     }
 
     /// <summary>
@@ -227,10 +207,7 @@ public class AppController : Controller
     {
         ArgumentException.ThrowIfNullOrEmpty(appId);
 
-        var history = await _configService.GetPublishTimelineHistoryAsync(appId, env.Value);
-
-        history = history.OrderByDescending(x => x.Version).ToList();
-
+        var history = await _releaseManagementService.GetAllAsync(appId, env.Value);
         var vms = history.Select(x => x.ToApiPublishTimelimeVM());
 
         return Json(vms);
@@ -248,20 +225,12 @@ public class AppController : Controller
     [HttpPost("rollback")]
     public async Task<IActionResult> Rollback(string historyId, EnvString env)
     {
-        _configController.ControllerContext.HttpContext = HttpContext;
+        var result = await _releaseManagementService.RollbackAsync(
+            new RollbackConfigurationCommand(historyId, env.Value));
+        if (result.Succeeded) return Ok();
 
-        var actionResult = await _configController.Rollback(historyId, env);
-        var status = actionResult as IStatusCodeActionResult;
-        var result = actionResult as JsonResult;
-
-        dynamic obj = result?.Value;
-        if (obj?.success ?? false) return Ok();
-
-        Response.StatusCode = status.StatusCode.Value;
-        return Json(new
-        {
-            obj?.message
-        });
+        Response.StatusCode = result.Error == ApplicationError.NotFound ? 404 : 400;
+        return Json(new { message = "回滚失败，请查看错误日志。" });
     }
 
     private (bool, string) CheckRequired(ApiAppVM model)

--- a/src/AgileConfig.Server.Apisite/Controllers/api/ConfigController.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/api/ConfigController.cs
@@ -3,7 +3,10 @@ using AgileConfig.Server.Apisite.Filters;
 using AgileConfig.Server.Apisite.Metrics;
 using AgileConfig.Server.Apisite.Models;
 using AgileConfig.Server.Apisite.Models.Mapping;
+using AgileConfig.Server.Application;
+using AgileConfig.Server.Application.Configurations;
 using AgileConfig.Server.Common;
+using AgileConfig.Server.Common.Resources;
 using AgileConfig.Server.Data.Entity;
 using AgileConfig.Server.IService;
 using Microsoft.AspNetCore.Http;
@@ -23,7 +26,7 @@ public class ConfigController : Controller
 {
     private readonly IAppService _appService;
     private readonly IMemoryCache _cacheMemory;
-    private readonly Controllers.ConfigController _configController;
+    private readonly IConfigurationManagementService _configurationManagementService;
     private readonly IConfigService _configService;
     private readonly IMeterService _meterService;
 
@@ -32,14 +35,14 @@ public class ConfigController : Controller
         IAppService appService,
         IMemoryCache cacheMemory,
         IMeterService meterService,
-        Controllers.ConfigController configController
+        IConfigurationManagementService configurationManagementService
     )
     {
         _configService = configService;
         _appService = appService;
         _cacheMemory = cacheMemory;
         _meterService = meterService;
-        _configController = configController;
+        _configurationManagementService = configurationManagementService;
     }
 
     /// <summary>
@@ -159,18 +162,22 @@ public class ConfigController : Controller
             });
         }
 
-        _configController.ControllerContext.HttpContext = HttpContext;
+        var config = model.ToConfigVM();
+        var result = await _configurationManagementService.CreateAsync(new CreateConfigurationCommand(
+            config.Id,
+            config.AppId,
+            config.Group,
+            config.Key,
+            config.Value,
+            config.Description,
+            env.Value));
 
-        var result = await _configController.Add(model.ToConfigVM(), env) as JsonResult;
-
-        dynamic obj = result?.Value;
-
-        if (obj?.success == true) return Created("/api/config/" + obj.data.Id, "");
+        if (result.Succeeded) return Created("/api/config/" + result.Value.Id, "");
 
         Response.StatusCode = 400;
         return Json(new
         {
-            obj?.message
+            message = GetCreateErrorMessage(result.Error, config.AppId)
         });
     }
 
@@ -198,17 +205,22 @@ public class ConfigController : Controller
             });
         }
 
-        _configController.ControllerContext.HttpContext = HttpContext;
         model.Id = id;
-        var result = await _configController.Edit(model.ToConfigVM(), env) as JsonResult;
-
-        dynamic obj = result?.Value;
-        if (obj?.success == true) return Ok();
+        var config = model.ToConfigVM();
+        var result = await _configurationManagementService.UpdateAsync(new UpdateConfigurationCommand(
+            config.Id,
+            config.AppId,
+            config.Group,
+            config.Key,
+            config.Value,
+            config.Description,
+            env.Value));
+        if (result.Succeeded) return Ok();
 
         Response.StatusCode = 400;
         return Json(new
         {
-            obj?.message
+            message = await GetUpdateErrorMessage(result.Error, config.AppId, id, env.Value)
         });
     }
 
@@ -225,18 +237,44 @@ public class ConfigController : Controller
     [HttpDelete("{id}")]
     public async Task<IActionResult> Delete(string id, EnvString env)
     {
-        _configController.ControllerContext.HttpContext = HttpContext;
-
-        var result = await _configController.Delete(id, env) as JsonResult;
-
-        dynamic obj = result?.Value;
-        if (obj?.success == true) return NoContent();
+        var result = await _configurationManagementService.DeleteAsync(
+            new DeleteConfigurationCommand(id, env.Value));
+        if (result.Succeeded) return NoContent();
 
         Response.StatusCode = 400;
         return Json(new
         {
-            obj?.message
+            message = result.Error == ApplicationError.NotFound
+                ? "未找到对应的配置项。"
+                : "删除配置失败，请查看错误日志"
         });
+    }
+
+    private static string GetCreateErrorMessage(ApplicationError error, string appId)
+    {
+        return error switch
+        {
+            ApplicationError.NotFound => Messages.AppNotExists(appId),
+            ApplicationError.Conflict => Messages.ConfigExists,
+            _ => Messages.CreateConfigFailed
+        };
+    }
+
+    private async Task<string> GetUpdateErrorMessage(
+        ApplicationError error,
+        string appId,
+        string configurationId,
+        string environment)
+    {
+        if (error == ApplicationError.Conflict) return Messages.ConfigKeyExists;
+
+        if (error == ApplicationError.NotFound)
+        {
+            var config = await _configService.GetAsync(configurationId, environment);
+            return config == null ? Messages.ConfigNotFound : Messages.AppNotExists(appId);
+        }
+
+        return "修改配置失败，请查看错误日志。";
     }
 
     private (bool, string) CheckRequired(ApiConfigVM model)

--- a/src/AgileConfig.Server.Apisite/Controllers/api/NodeController.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/api/NodeController.cs
@@ -1,11 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using AgileConfig.Server.Application;
 using AgileConfig.Server.Apisite.Controllers.api.Models;
 using AgileConfig.Server.Apisite.Filters;
-using AgileConfig.Server.Apisite.Models;
 using AgileConfig.Server.Apisite.Models.Mapping;
-using AgileConfig.Server.Common.EventBus;
+using AgileConfig.Server.Common.Resources;
 using AgileConfig.Server.IService;
 using Microsoft.AspNetCore.Mvc;
 
@@ -18,21 +18,11 @@ namespace AgileConfig.Server.Apisite.Controllers.api;
 [Route("api/[controller]")]
 public class NodeController : Controller
 {
-    private readonly IRemoteServerNodeProxy _remoteServerNodeProxy;
-    private readonly IServerNodeService _serverNodeService;
-    private readonly ISysLogService _sysLogService;
-    private readonly ITinyEventBus _tinyEventBus;
+    private readonly INodeManagementService _nodeManagementService;
 
-    public NodeController(IServerNodeService serverNodeService,
-        ISysLogService sysLogService,
-        IRemoteServerNodeProxy remoteServerNodeProxy,
-        ITinyEventBus tinyEventBus
-    )
+    public NodeController(INodeManagementService nodeManagementService)
     {
-        _serverNodeService = serverNodeService;
-        _sysLogService = sysLogService;
-        _remoteServerNodeProxy = remoteServerNodeProxy;
-        _tinyEventBus = tinyEventBus;
+        _nodeManagementService = nodeManagementService;
     }
 
     /// <summary>
@@ -42,7 +32,7 @@ public class NodeController : Controller
     [HttpGet]
     public async Task<ActionResult<IEnumerable<ApiNodeVM>>> GetAll()
     {
-        var nodes = await _serverNodeService.GetAllNodesAsync();
+        var nodes = await _nodeManagementService.GetAllAsync();
 
         var vms = nodes.Select(x => x.ToApiNodeVM());
 
@@ -70,17 +60,13 @@ public class NodeController : Controller
             });
         }
 
-        var ctrl = new ServerNodeController(_serverNodeService, _sysLogService, _remoteServerNodeProxy, _tinyEventBus);
-        ctrl.ControllerContext.HttpContext = HttpContext;
-        var result = await ctrl.Add(model.ToServerNodeVM()) as JsonResult;
-
-        dynamic obj = result?.Value;
-        if (obj?.success == true) return Created("", "");
+        var result = await _nodeManagementService.CreateAsync(new CreateNodeCommand(model.Address, model.Remark));
+        if (result.Succeeded) return Created("", "");
 
         Response.StatusCode = 400;
         return Json(new
         {
-            obj?.message
+            message = GetCreateErrorMessage(result.Error)
         });
     }
 
@@ -95,24 +81,35 @@ public class NodeController : Controller
     [HttpDelete]
     public async Task<IActionResult> Delete([FromQuery] string address)
     {
-        var ctrl = new ServerNodeController(_serverNodeService, _sysLogService, _remoteServerNodeProxy, _tinyEventBus);
-        ctrl.ControllerContext.HttpContext = HttpContext;
-        var result = await ctrl.Delete(new ServerNodeVM { Address = address }) as JsonResult;
-
-        dynamic obj = result?.Value;
-        if (obj?.success == true) return NoContent();
+        var result = await _nodeManagementService.DeleteAsync(address);
+        if (result.Succeeded) return NoContent();
 
         Response.StatusCode = 400;
         return Json(new
         {
-            obj?.message
+            message = GetDeleteErrorMessage(result.Error)
         });
     }
 
-    private (bool, string) CheckRequired(ApiNodeVM model)
+    private static (bool, string) CheckRequired(ApiNodeVM model)
     {
         if (string.IsNullOrEmpty(model.Address)) return (false, "Address is required");
 
         return (true, "");
+    }
+
+    private static string GetCreateErrorMessage(ApplicationError error)
+    {
+        return error == ApplicationError.Conflict ? Messages.NodeAlreadyExists : Messages.AddNodeFailed;
+    }
+
+    private static string GetDeleteErrorMessage(ApplicationError error)
+    {
+        return error switch
+        {
+            ApplicationError.Forbidden => Messages.DemoModeNoNodeDelete,
+            ApplicationError.NotFound => Messages.NodeNotFound,
+            _ => Messages.DeleteNodeFailed
+        };
     }
 }

--- a/src/AgileConfig.Server.Apisite/Controllers/api/RegisterCenterController.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/api/RegisterCenterController.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Agile.Config.Protocol;
+using AgileConfig.Server.Application;
 using AgileConfig.Server.Apisite.Controllers.api.Models;
 using AgileConfig.Server.Apisite.Models.Mapping;
-using AgileConfig.Server.Common.EventBus;
 using AgileConfig.Server.Data.Entity;
-using AgileConfig.Server.Event;
 using AgileConfig.Server.IService;
 using Microsoft.AspNetCore.Mvc;
 
@@ -19,18 +19,16 @@ namespace AgileConfig.Server.Apisite.Controllers.api;
 [ApiController]
 public class RegisterCenterController : Controller
 {
-    private readonly IRegisterCenterService _registerCenterService;
+    private readonly IServiceInstanceManagementService _serviceInstanceManagementService;
     private readonly IServiceInfoService _serviceInfoService;
-    private readonly ITinyEventBus _tinyEventBus;
 
-    public RegisterCenterController(IRegisterCenterService registerCenterService
-        , IServiceInfoService serviceInfoService,
-        ITinyEventBus tinyEventBus
+    public RegisterCenterController(
+        IServiceInstanceManagementService serviceInstanceManagementService,
+        IServiceInfoService serviceInfoService
     )
     {
-        _registerCenterService = registerCenterService;
+        _serviceInstanceManagementService = serviceInstanceManagementService;
         _serviceInfoService = serviceInfoService;
-        _tinyEventBus = tinyEventBus;
     }
 
     [HttpPost]
@@ -38,16 +36,22 @@ public class RegisterCenterController : Controller
     {
         ArgumentNullException.ThrowIfNull(model);
 
-        var entity = model.ToServiceInfo();
-        entity.RegisterWay = RegisterWay.Auto;
-
-        var id = await _registerCenterService.RegisterAsync(entity);
-
-        _tinyEventBus.Fire(new ServiceRegisteredEvent(id));
+        var result = await _serviceInstanceManagementService.RegisterAsync(new RegisterServiceInstanceCommand(
+            model.ServiceId,
+            model.ServiceName,
+            model.Ip,
+            model.Port,
+            JsonSerializer.Serialize(model.MetaData ?? []),
+            model.CheckUrl,
+            model.AlarmUrl,
+            model.HeartBeatMode,
+            RegisterWay.Auto,
+            RejectExisting: false,
+            AcceptMissingIdentifier: true));
 
         return new RegisterResultVM
         {
-            UniqueId = id
+            UniqueId = result.Succeeded ? result.Value.UniqueId : null
         };
     }
 
@@ -55,15 +59,8 @@ public class RegisterCenterController : Controller
     [HttpDelete("{id}")]
     public async Task<ActionResult<RegisterResultVM>> UnRegister(string id, [FromBody] RegisterServiceInfoVM vm)
     {
-        var entity = await _serviceInfoService.GetByUniqueIdAsync(id);
-        if (entity == null) return NotFound();
-
-        var result = await _registerCenterService.UnRegisterAsync(id);
-        if (!result)
-            if (!string.IsNullOrEmpty(vm?.ServiceId))
-                result = await _registerCenterService.UnRegisterByServiceIdAsync(vm.ServiceId);
-
-        if (result) _tinyEventBus.Fire(new ServiceUnRegisterEvent(id));
+        var result = await _serviceInstanceManagementService.UnregisterAsync(id, vm?.ServiceId);
+        if (!result.Succeeded && result.Error == ApplicationError.NotFound) return NotFound();
 
         return new RegisterResultVM
         {
@@ -76,17 +73,14 @@ public class RegisterCenterController : Controller
     {
         ArgumentNullException.ThrowIfNull(param);
 
-        var serviceHeartbeatResult = false;
-        if (!string.IsNullOrEmpty(param.UniqueId))
-            serviceHeartbeatResult = await _registerCenterService.ReceiveHeartbeatAsync(param.UniqueId);
+        var result = await _serviceInstanceManagementService.ReceiveHeartbeatAsync(param.UniqueId);
 
-        if (serviceHeartbeatResult)
+        if (result.Succeeded)
         {
-            var md5 = await _serviceInfoService.ServicesMD5Cache();
             return new HeartbeatResultVM
             {
                 Action = ActionConst.Ping,
-                Data = md5,
+                Data = result.Value.ServicesVersion,
                 Module = ActionModule.RegisterCenter
             };
         }

--- a/src/AgileConfig.Server.Apisite/Controllers/api/v2/ApplicationsController.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/api/v2/ApplicationsController.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using AgileConfig.Server.Application;
 using AgileConfig.Server.Apisite.Controllers.api.v2.Models;
 using AgileConfig.Server.Apisite.Filters;
-using AgileConfig.Server.Common.Resources;
 using AgileConfig.Server.Data.Entity;
 using AgileConfig.Server.IService;
 using Microsoft.AspNetCore.Mvc;
@@ -64,7 +63,7 @@ public sealed class ApplicationsController : ControllerBase
                 result,
                 "Application creation failed.",
                 "An application with the same identifier already exists.",
-                Messages.CreateAppFailed);
+                "The application could not be created.");
 
         var application = await _applicationManagementService.GetAsync(result.Value.Id);
         if (application == null) return Problem(title: "The created application could not be loaded.");
@@ -86,7 +85,10 @@ public sealed class ApplicationsController : ControllerBase
             request.IsInheritanceSource,
             request.InheritsFrom));
         if (!result.Succeeded)
-            return ToFailure(result, "Application update failed.", operationDetail: Messages.UpdateAppFailed);
+            return ToFailure(
+                result,
+                "Application update failed.",
+                operationDetail: "The application could not be updated.");
 
         var application = await _applicationManagementService.GetAsync(result.Value.Id);
         return application == null
@@ -101,7 +103,10 @@ public sealed class ApplicationsController : ControllerBase
         var result = await _applicationManagementService.DeleteAsync(new DeleteApplicationCommand(applicationId));
         return result.Succeeded
             ? NoContent()
-            : ToFailure(result, "Application deletion failed.", operationDetail: Messages.UpdateAppFailed);
+            : ToFailure(
+                result,
+                "Application deletion failed.",
+                operationDetail: "The application could not be deleted.");
     }
 
     private ActionResult ToFailure(
@@ -114,7 +119,7 @@ public sealed class ApplicationsController : ControllerBase
         {
             ApplicationError.Conflict => conflictDetail ??
                 "The application could not be updated because it conflicts with another resource.",
-            ApplicationError.ValidationFailed => Messages.DemoModeNoTestAppEdit,
+            ApplicationError.ValidationFailed => "The application cannot be modified in preview mode.",
             ApplicationError.OperationFailed => operationDetail,
             _ => null
         };

--- a/src/AgileConfig.Server.Apisite/Controllers/api/v2/ApplicationsController.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/api/v2/ApplicationsController.cs
@@ -57,7 +57,8 @@ public sealed class ApplicationsController : ControllerBase
             request.Secret,
             request.Enabled,
             request.IsInheritanceSource,
-            request.InheritsFrom));
+            request.InheritsFrom,
+            ValidateInheritanceReferences: true));
         if (!result.Succeeded)
             return ToFailure(
                 result,
@@ -83,7 +84,8 @@ public sealed class ApplicationsController : ControllerBase
             request.Secret,
             request.Enabled,
             request.IsInheritanceSource,
-            request.InheritsFrom));
+            request.InheritsFrom,
+            ValidateInheritanceReferences: true));
         if (!result.Succeeded)
             return ToFailure(
                 result,
@@ -119,7 +121,7 @@ public sealed class ApplicationsController : ControllerBase
         {
             ApplicationError.Conflict => conflictDetail ??
                 "The application could not be updated because it conflicts with another resource.",
-            ApplicationError.ValidationFailed => "The application cannot be modified in preview mode.",
+            ApplicationError.ValidationFailed => "The application request is invalid.",
             ApplicationError.OperationFailed => operationDetail,
             _ => null
         };

--- a/src/AgileConfig.Server.Apisite/Controllers/api/v2/ApplicationsController.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/api/v2/ApplicationsController.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AgileConfig.Server.Application;
+using AgileConfig.Server.Apisite.Controllers.api.v2.Models;
+using AgileConfig.Server.Apisite.Filters;
+using AgileConfig.Server.Common.Resources;
+using AgileConfig.Server.Data.Entity;
+using AgileConfig.Server.IService;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AgileConfig.Server.Apisite.Controllers.api.v2;
+
+/// <summary>
+///     Version 2 application resources.
+/// </summary>
+[ApiController]
+[Route("api/v2/applications")]
+[TypeFilter(typeof(AdmBasicAuthenticationAttribute))]
+public sealed class ApplicationsController : ControllerBase
+{
+    private readonly IApplicationManagementService _applicationManagementService;
+
+    public ApplicationsController(IApplicationManagementService applicationManagementService)
+    {
+        _applicationManagementService = applicationManagementService;
+    }
+
+    [HttpGet]
+    [TypeFilter(typeof(PermissionCheckByBasicAttribute), Arguments = new object[] { Functions.App_Read })]
+    public async Task<ActionResult<IReadOnlyList<ApplicationResource>>> GetAll()
+    {
+        var applications = await _applicationManagementService.GetAllAsync();
+        var resources = applications
+            .Select(x => x.Application.ToV2Resource(x.InheritedApplicationIds))
+            .ToList();
+        return Ok(resources);
+    }
+
+    [HttpGet("{applicationId}", Name = RouteNames.Application)]
+    [TypeFilter(typeof(PermissionCheckByBasicAttribute), Arguments = new object[] { Functions.App_Read })]
+    public async Task<ActionResult<ApplicationResource>> GetById(string applicationId)
+    {
+        var application = await _applicationManagementService.GetAsync(applicationId);
+        return application == null
+            ? NotFound()
+            : Ok(application.Application.ToV2Resource(application.InheritedApplicationIds));
+    }
+
+    [HttpPost]
+    [TypeFilter(typeof(PermissionCheckByBasicAttribute), Arguments = new object[] { Functions.App_Add })]
+    public async Task<ActionResult<ApplicationResource>> Create(CreateApplicationRequest request)
+    {
+        var result = await _applicationManagementService.CreateAsync(new CreateApplicationCommand(
+            request.Id,
+            request.Name,
+            request.Group,
+            request.Secret,
+            request.Enabled,
+            request.IsInheritanceSource,
+            request.InheritsFrom));
+        if (!result.Succeeded)
+            return ToFailure(
+                result,
+                "Application creation failed.",
+                "An application with the same identifier already exists.",
+                Messages.CreateAppFailed);
+
+        var application = await _applicationManagementService.GetAsync(result.Value.Id);
+        if (application == null) return Problem(title: "The created application could not be loaded.");
+
+        var resource = application.Application.ToV2Resource(application.InheritedApplicationIds);
+        return CreatedAtRoute(RouteNames.Application, new { applicationId = resource.Id }, resource);
+    }
+
+    [HttpPut("{applicationId}")]
+    [TypeFilter(typeof(PermissionCheckByBasicAttribute), Arguments = new object[] { Functions.App_Edit })]
+    public async Task<ActionResult<ApplicationResource>> Update(string applicationId, UpdateApplicationRequest request)
+    {
+        var result = await _applicationManagementService.UpdateAsync(new UpdateApplicationCommand(
+            applicationId,
+            request.Name,
+            request.Group,
+            request.Secret,
+            request.Enabled,
+            request.IsInheritanceSource,
+            request.InheritsFrom));
+        if (!result.Succeeded)
+            return ToFailure(result, "Application update failed.", operationDetail: Messages.UpdateAppFailed);
+
+        var application = await _applicationManagementService.GetAsync(result.Value.Id);
+        return application == null
+            ? Problem(title: "The updated application could not be loaded.")
+            : Ok(application.Application.ToV2Resource(application.InheritedApplicationIds));
+    }
+
+    [HttpDelete("{applicationId}")]
+    [TypeFilter(typeof(PermissionCheckByBasicAttribute), Arguments = new object[] { Functions.App_Delete })]
+    public async Task<IActionResult> Delete(string applicationId)
+    {
+        var result = await _applicationManagementService.DeleteAsync(new DeleteApplicationCommand(applicationId));
+        return result.Succeeded
+            ? NoContent()
+            : ToFailure(result, "Application deletion failed.", operationDetail: Messages.UpdateAppFailed);
+    }
+
+    private ActionResult ToFailure(
+        ApplicationResult<App> result,
+        string title,
+        string conflictDetail = null,
+        string operationDetail = null)
+    {
+        var detail = result.Error switch
+        {
+            ApplicationError.Conflict => conflictDetail ??
+                "The application could not be updated because it conflicts with another resource.",
+            ApplicationError.ValidationFailed => Messages.DemoModeNoTestAppEdit,
+            ApplicationError.OperationFailed => operationDetail,
+            _ => null
+        };
+        var statusCode = result.Error switch
+        {
+            ApplicationError.NotFound => 404,
+            ApplicationError.Conflict => 409,
+            ApplicationError.ValidationFailed => 400,
+            ApplicationError.Forbidden => 403,
+            _ => 500
+        };
+        return Problem(statusCode: statusCode, title: title, detail: detail);
+    }
+
+}
+
+internal static class RouteNames
+{
+    public const string Application = "V2_GetApplication";
+    public const string Configuration = "V2_GetConfiguration";
+    public const string Release = "V2_GetRelease";
+    public const string Node = "V2_GetNode";
+    public const string ServiceInstance = "V2_GetServiceInstance";
+}

--- a/src/AgileConfig.Server.Apisite/Controllers/api/v2/ConfigurationsController.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/api/v2/ConfigurationsController.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AgileConfig.Server.Application;
+using AgileConfig.Server.Application.Configurations;
+using AgileConfig.Server.Apisite.Controllers.api.v2.Models;
+using AgileConfig.Server.Apisite.Filters;
+using AgileConfig.Server.Data.Entity;
+using AgileConfig.Server.IService;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AgileConfig.Server.Apisite.Controllers.api.v2;
+
+/// <summary>
+///     Version 2 application configuration resources.
+/// </summary>
+[ApiController]
+[Route("api/v2/applications/{applicationId}/environments/{environment}/configurations")]
+[TypeFilter(typeof(AdmBasicAuthenticationAttribute))]
+[TypeFilter(typeof(V2EnvironmentFilterAttribute))]
+public sealed class ConfigurationsController : ControllerBase
+{
+    private readonly IApplicationManagementService _applicationManagementService;
+    private readonly IConfigurationManagementService _configurationManagementService;
+
+    public ConfigurationsController(
+        IApplicationManagementService applicationManagementService,
+        IConfigurationManagementService configurationManagementService)
+    {
+        _applicationManagementService = applicationManagementService;
+        _configurationManagementService = configurationManagementService;
+    }
+
+    [HttpGet]
+    [TypeFilter(typeof(PermissionCheckByBasicAttribute), Arguments = new object[] { Functions.Config_Read })]
+    public async Task<ActionResult<IReadOnlyList<ConfigurationResource>>> GetAll(
+        string applicationId,
+        string environment)
+    {
+        if (await _applicationManagementService.GetAsync(applicationId) == null) return NotFound();
+
+        var configurations = await _configurationManagementService.GetAllAsync(applicationId, environment);
+        return Ok(configurations.Select(x => x.ToV2Resource()).ToList());
+    }
+
+    [HttpGet("{configurationId}", Name = RouteNames.Configuration)]
+    [TypeFilter(typeof(PermissionCheckByBasicAttribute), Arguments = new object[] { Functions.Config_Read })]
+    public async Task<ActionResult<ConfigurationResource>> GetById(
+        string applicationId,
+        string environment,
+        string configurationId)
+    {
+        var configuration = await FindConfiguration(applicationId, environment, configurationId);
+        return configuration == null ? NotFound() : Ok(configuration.ToV2Resource());
+    }
+
+    [HttpPost]
+    [TypeFilter(typeof(PermissionCheckByBasicAttribute), Arguments = new object[] { Functions.Config_Add })]
+    public async Task<ActionResult<ConfigurationResource>> Create(
+        string applicationId,
+        string environment,
+        CreateConfigurationRequest request)
+    {
+        var result = await _configurationManagementService.CreateAsync(new CreateConfigurationCommand(
+            null,
+            applicationId,
+            request.Group,
+            request.Key,
+            request.Value,
+            request.Description,
+            environment));
+        if (!result.Succeeded) return MapFailure(result.Error, "Configuration creation failed.");
+
+        var resource = result.Value;
+
+        return CreatedAtRoute(RouteNames.Configuration, new
+        {
+            applicationId,
+            environment,
+            configurationId = resource.Id
+        }, resource.ToV2Resource());
+    }
+
+    [HttpPut("{configurationId}")]
+    [TypeFilter(typeof(PermissionCheckByBasicAttribute), Arguments = new object[] { Functions.Config_Edit })]
+    public async Task<ActionResult<ConfigurationResource>> Update(
+        string applicationId,
+        string environment,
+        string configurationId,
+        UpdateConfigurationRequest request)
+    {
+        var existing = await FindConfiguration(applicationId, environment, configurationId);
+        if (existing == null) return NotFound();
+
+        var result = await _configurationManagementService.UpdateAsync(new UpdateConfigurationCommand(
+            configurationId,
+            applicationId,
+            request.Group,
+            request.Key,
+            request.Value,
+            request.Description,
+            environment));
+        if (!result.Succeeded) return MapFailure(result.Error, "Configuration update failed.");
+
+        return Ok(result.Value.ToV2Resource());
+    }
+
+    [HttpDelete("{configurationId}")]
+    [TypeFilter(typeof(PermissionCheckByBasicAttribute), Arguments = new object[] { Functions.Config_Delete })]
+    public async Task<IActionResult> Delete(string applicationId, string environment, string configurationId)
+    {
+        if (await FindConfiguration(applicationId, environment, configurationId) == null) return NotFound();
+
+        var result = await _configurationManagementService.DeleteAsync(
+            new DeleteConfigurationCommand(configurationId, environment));
+        return result.Succeeded ? NoContent() : MapFailure(result.Error, "Configuration deletion failed.");
+    }
+
+    private async Task<Config> FindConfiguration(string applicationId, string environment, string configurationId)
+    {
+        return await _configurationManagementService.GetAsync(applicationId, environment, configurationId);
+    }
+
+    private ObjectResult MapFailure(ApplicationError error, string title)
+    {
+        return error switch
+        {
+            ApplicationError.NotFound => Problem(statusCode: 404, title: "Configuration not found."),
+            ApplicationError.Conflict => Problem(statusCode: 409, title: "Configuration conflict.",
+                detail: "A configuration with the same group and key already exists."),
+            ApplicationError.ValidationFailed => Problem(statusCode: 400, title: "Invalid configuration request."),
+            ApplicationError.Forbidden => Problem(statusCode: 403, title: "Configuration operation forbidden."),
+            _ => Problem(statusCode: 500, title: title)
+        };
+    }
+}

--- a/src/AgileConfig.Server.Apisite/Controllers/api/v2/Models/ApplicationModels.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/api/v2/Models/ApplicationModels.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace AgileConfig.Server.Apisite.Controllers.api.v2.Models;
+
+public sealed class ApplicationResource
+{
+    public string Id { get; init; }
+    public string Name { get; init; }
+    public string Group { get; init; }
+    public bool Enabled { get; init; }
+    public bool IsInheritanceSource { get; init; }
+    public IReadOnlyList<string> InheritsFrom { get; init; } = [];
+    public string Creator { get; init; }
+    public DateTime CreatedAt { get; init; }
+    public DateTime? UpdatedAt { get; init; }
+}
+
+public sealed class CreateApplicationRequest
+{
+    [Required, MaxLength(36)]
+    public string Id { get; init; }
+
+    [Required, MaxLength(50)]
+    public string Name { get; init; }
+
+    [MaxLength(50)]
+    public string Group { get; init; }
+
+    [MaxLength(36)]
+    public string Secret { get; init; }
+
+    public bool Enabled { get; init; } = true;
+    public bool IsInheritanceSource { get; init; }
+    public List<string> InheritsFrom { get; init; } = [];
+}
+
+public sealed class UpdateApplicationRequest
+{
+    [Required, MaxLength(50)]
+    public string Name { get; init; }
+
+    [MaxLength(50)]
+    public string Group { get; init; }
+
+    [MaxLength(36)]
+    public string Secret { get; init; }
+
+    public bool Enabled { get; init; }
+    public bool IsInheritanceSource { get; init; }
+    public List<string> InheritsFrom { get; init; } = [];
+}

--- a/src/AgileConfig.Server.Apisite/Controllers/api/v2/Models/ConfigurationModels.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/api/v2/Models/ConfigurationModels.cs
@@ -1,0 +1,60 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace AgileConfig.Server.Apisite.Controllers.api.v2.Models;
+
+public sealed class ConfigurationResource
+{
+    public string Id { get; init; }
+    public string ApplicationId { get; init; }
+    public string Environment { get; init; }
+    public string Group { get; init; }
+    public string Key { get; init; }
+    public string Value { get; init; }
+    public string Description { get; init; }
+    public string Status { get; init; }
+    public string PublicationStatus { get; init; }
+    public string ChangeType { get; init; }
+    public DateTime CreatedAt { get; init; }
+    public DateTime? UpdatedAt { get; init; }
+}
+
+public sealed class PublishedConfigurationResource
+{
+    public string Id { get; init; }
+    public string ApplicationId { get; init; }
+    public string Environment { get; init; }
+    public string Group { get; init; }
+    public string Key { get; init; }
+    public string Value { get; init; }
+}
+
+public sealed class CreateConfigurationRequest
+{
+    [MaxLength(100)]
+    public string Group { get; init; }
+
+    [Required, MaxLength(100)]
+    public string Key { get; init; }
+
+    [MaxLength(4000)]
+    public string Value { get; init; }
+
+    [MaxLength(200)]
+    public string Description { get; init; }
+}
+
+public sealed class UpdateConfigurationRequest
+{
+    [MaxLength(100)]
+    public string Group { get; init; }
+
+    [Required, MaxLength(100)]
+    public string Key { get; init; }
+
+    [MaxLength(4000)]
+    public string Value { get; init; }
+
+    [MaxLength(200)]
+    public string Description { get; init; }
+}

--- a/src/AgileConfig.Server.Apisite/Controllers/api/v2/Models/NodeModels.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/api/v2/Models/NodeModels.cs
@@ -1,0 +1,22 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace AgileConfig.Server.Apisite.Controllers.api.v2.Models;
+
+public sealed class NodeResource
+{
+    public string Id { get; init; }
+    public string Address { get; init; }
+    public string Remark { get; init; }
+    public string Status { get; init; }
+    public DateTime? LastEchoAt { get; init; }
+}
+
+public sealed class CreateNodeRequest
+{
+    [Required, MaxLength(100), Url]
+    public string Address { get; init; }
+
+    [MaxLength(50)]
+    public string Remark { get; init; }
+}

--- a/src/AgileConfig.Server.Apisite/Controllers/api/v2/Models/ReleaseModels.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/api/v2/Models/ReleaseModels.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace AgileConfig.Server.Apisite.Controllers.api.v2.Models;
+
+public sealed class ReleaseResource
+{
+    public string Id { get; init; }
+    public string ApplicationId { get; init; }
+    public string Environment { get; init; }
+    public int Version { get; init; }
+    public string Log { get; init; }
+    public string PublishedBy { get; init; }
+    public DateTime? PublishedAt { get; init; }
+}
+
+public sealed class CreateReleaseRequest
+{
+    [MaxLength(100)]
+    public string Log { get; init; }
+
+    public List<string> ConfigurationIds { get; init; }
+}
+
+public sealed class CreateRollbackRequest
+{
+    [Required]
+    public string ReleaseId { get; init; }
+}

--- a/src/AgileConfig.Server.Apisite/Controllers/api/v2/Models/ServiceInstanceModels.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/api/v2/Models/ServiceInstanceModels.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
 
 namespace AgileConfig.Server.Apisite.Controllers.api.v2.Models;
 
@@ -20,8 +21,10 @@ public sealed class ServiceInstanceResource
     public DateTime? LastHeartbeatAt { get; init; }
 }
 
-public sealed class RegisterServiceInstanceRequest
+public sealed class RegisterServiceInstanceRequest : IValidatableObject
 {
+    public const int MetadataMaxLength = 2000;
+
     [Required, MaxLength(100)]
     public string ServiceId { get; init; }
 
@@ -44,6 +47,17 @@ public sealed class RegisterServiceInstanceRequest
 
     [MaxLength(2000)]
     public string AlarmUrl { get; init; }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        var metadataJson = JsonSerializer.Serialize(Metadata ?? []);
+        if (metadataJson.Length > MetadataMaxLength)
+        {
+            yield return new ValidationResult(
+                $"Serialized metadata cannot exceed {MetadataMaxLength} characters.",
+                [nameof(Metadata)]);
+        }
+    }
 }
 
 public sealed class HeartbeatResource

--- a/src/AgileConfig.Server.Apisite/Controllers/api/v2/Models/ServiceInstanceModels.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/api/v2/Models/ServiceInstanceModels.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace AgileConfig.Server.Apisite.Controllers.api.v2.Models;
+
+public sealed class ServiceInstanceResource
+{
+    public string Id { get; init; }
+    public string ServiceId { get; init; }
+    public string Name { get; init; }
+    public string IpAddress { get; init; }
+    public int? Port { get; init; }
+    public IReadOnlyList<string> Metadata { get; init; } = [];
+    public string Status { get; init; }
+    public string HeartbeatMode { get; init; }
+    public string HealthCheckUrl { get; init; }
+    public string AlarmUrl { get; init; }
+    public DateTime? RegisteredAt { get; init; }
+    public DateTime? LastHeartbeatAt { get; init; }
+}
+
+public sealed class RegisterServiceInstanceRequest
+{
+    [Required, MaxLength(100)]
+    public string ServiceId { get; init; }
+
+    [Required, MaxLength(100)]
+    public string Name { get; init; }
+
+    [Required, MaxLength(100)]
+    public string IpAddress { get; init; }
+
+    [Range(1, 65535)]
+    public int? Port { get; init; }
+
+    public List<string> Metadata { get; init; } = [];
+
+    [Required, RegularExpression("^(client|server|none)$")]
+    public string HeartbeatMode { get; init; }
+
+    [MaxLength(2000)]
+    public string HealthCheckUrl { get; init; }
+
+    [MaxLength(2000)]
+    public string AlarmUrl { get; init; }
+}
+
+public sealed class HeartbeatResource
+{
+    public string ServiceInstanceId { get; init; }
+    public DateTime ReceivedAt { get; init; }
+    public string ServicesVersion { get; init; }
+}

--- a/src/AgileConfig.Server.Apisite/Controllers/api/v2/Models/V2MappingExtensions.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/api/v2/Models/V2MappingExtensions.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using AgileConfig.Server.Data.Entity;
+using Microsoft.AspNetCore.WebUtilities;
+using Newtonsoft.Json;
+
+namespace AgileConfig.Server.Apisite.Controllers.api.v2.Models;
+
+internal static class V2MappingExtensions
+{
+    public static ApplicationResource ToV2Resource(this App app, IReadOnlyList<string> inheritsFrom)
+    {
+        return new ApplicationResource
+        {
+            Id = app.Id,
+            Name = app.Name,
+            Group = app.Group,
+            Enabled = app.Enabled,
+            IsInheritanceSource = app.Type == AppType.Inheritance,
+            InheritsFrom = inheritsFrom,
+            Creator = app.Creator,
+            CreatedAt = app.CreateTime,
+            UpdatedAt = app.UpdateTime
+        };
+    }
+
+    public static ConfigurationResource ToV2Resource(this Config config)
+    {
+        return new ConfigurationResource
+        {
+            Id = config.Id,
+            ApplicationId = config.AppId,
+            Environment = config.Env,
+            Group = config.Group,
+            Key = config.Key,
+            Value = config.Value,
+            Description = config.Description,
+            Status = config.Status.ToString(),
+            PublicationStatus = config.OnlineStatus.ToString(),
+            ChangeType = config.EditStatus.ToString(),
+            CreatedAt = config.CreateTime,
+            UpdatedAt = config.UpdateTime
+        };
+    }
+
+    public static ReleaseResource ToV2Resource(this PublishTimeline timeline)
+    {
+        return new ReleaseResource
+        {
+            Id = timeline.Id,
+            ApplicationId = timeline.AppId,
+            Environment = timeline.Env,
+            Version = timeline.Version,
+            Log = timeline.Log,
+            PublishedBy = timeline.PublishUserName ?? timeline.PublishUserId,
+            PublishedAt = timeline.PublishTime
+        };
+    }
+
+    public static NodeResource ToV2Resource(this ServerNode node)
+    {
+        return new NodeResource
+        {
+            Id = WebEncoders.Base64UrlEncode(System.Text.Encoding.UTF8.GetBytes(node.Id)),
+            Address = node.Id,
+            Remark = node.Remark,
+            Status = node.Status.ToString(),
+            LastEchoAt = node.LastEchoTime
+        };
+    }
+
+    public static string DecodeNodeId(string id)
+    {
+        try
+        {
+            return System.Text.Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(id));
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+
+    public static ServiceInstanceResource ToV2Resource(this ServiceInfo instance)
+    {
+        var metadata = new List<string>();
+        try
+        {
+            metadata = JsonConvert.DeserializeObject<List<string>>(instance.MetaData) ?? [];
+        }
+        catch (JsonException)
+        {
+        }
+
+        return new ServiceInstanceResource
+        {
+            Id = instance.Id,
+            ServiceId = instance.ServiceId,
+            Name = instance.ServiceName,
+            IpAddress = instance.Ip,
+            Port = instance.Port,
+            Metadata = metadata,
+            Status = instance.Status.ToString(),
+            HeartbeatMode = instance.HeartBeatMode,
+            HealthCheckUrl = instance.CheckUrl,
+            AlarmUrl = instance.AlarmUrl,
+            RegisteredAt = instance.RegisterTime,
+            LastHeartbeatAt = instance.LastHeartBeat
+        };
+    }
+}

--- a/src/AgileConfig.Server.Apisite/Controllers/api/v2/NodesController.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/api/v2/NodesController.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AgileConfig.Server.Application;
+using AgileConfig.Server.Apisite.Controllers.api.v2.Models;
+using AgileConfig.Server.Apisite.Filters;
+using AgileConfig.Server.IService;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AgileConfig.Server.Apisite.Controllers.api.v2;
+
+/// <summary>
+///     Version 2 cluster node resources.
+/// </summary>
+[ApiController]
+[Route("api/v2/nodes")]
+[TypeFilter(typeof(AdmBasicAuthenticationAttribute))]
+public sealed class NodesController : ControllerBase
+{
+    private readonly INodeManagementService _nodeManagementService;
+
+    public NodesController(INodeManagementService nodeManagementService)
+    {
+        _nodeManagementService = nodeManagementService;
+    }
+
+    [HttpGet]
+    [TypeFilter(typeof(PermissionCheckByBasicAttribute), Arguments = new object[] { Functions.Node_Read })]
+    public async Task<ActionResult<IReadOnlyList<NodeResource>>> GetAll()
+    {
+        var nodes = await _nodeManagementService.GetAllAsync();
+        return Ok(nodes.Select(x => x.ToV2Resource()).ToList());
+    }
+
+    [HttpGet("{nodeId}", Name = RouteNames.Node)]
+    [TypeFilter(typeof(PermissionCheckByBasicAttribute), Arguments = new object[] { Functions.Node_Read })]
+    public async Task<ActionResult<NodeResource>> GetById(string nodeId)
+    {
+        var node = await FindNode(nodeId);
+        return node == null ? NotFound() : Ok(node.ToV2Resource());
+    }
+
+    [HttpPost]
+    [TypeFilter(typeof(PermissionCheckByBasicAttribute), Arguments = new object[] { Functions.Node_Add })]
+    public async Task<ActionResult<NodeResource>> Create(CreateNodeRequest request)
+    {
+        var result = await _nodeManagementService.CreateAsync(new CreateNodeCommand(request.Address, request.Remark));
+        if (!result.Succeeded) return MapFailure(result.Error, "Node creation failed.");
+
+        var resource = result.Value.ToV2Resource();
+        return CreatedAtRoute(RouteNames.Node, new { nodeId = resource.Id }, resource);
+    }
+
+    [HttpDelete("{nodeId}")]
+    [TypeFilter(typeof(PermissionCheckByBasicAttribute), Arguments = new object[] { Functions.Node_Delete })]
+    public async Task<IActionResult> Delete(string nodeId)
+    {
+        var address = V2MappingExtensions.DecodeNodeId(nodeId);
+        if (address == null) return NotFound();
+
+        var result = await _nodeManagementService.DeleteAsync(address);
+        return result.Succeeded ? NoContent() : MapFailure(result.Error, "Node deletion failed.");
+    }
+
+    private async Task<AgileConfig.Server.Data.Entity.ServerNode> FindNode(string nodeId)
+    {
+        var address = V2MappingExtensions.DecodeNodeId(nodeId);
+        return address == null ? null : await _nodeManagementService.GetByAddressAsync(address);
+    }
+
+    private ObjectResult MapFailure(ApplicationError error, string title)
+    {
+        return error switch
+        {
+            ApplicationError.Conflict => Problem(statusCode: 409, title: "Node conflict.",
+                detail: "A node with the same address already exists."),
+            ApplicationError.NotFound => Problem(statusCode: 404, title: "Node not found."),
+            ApplicationError.ValidationFailed => Problem(statusCode: 400, title: "Invalid node request."),
+            ApplicationError.Forbidden => Problem(statusCode: 403, title: "Node operation forbidden."),
+            _ => Problem(statusCode: 500, title: title)
+        };
+    }
+}

--- a/src/AgileConfig.Server.Apisite/Controllers/api/v2/PublishedConfigurationsController.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/api/v2/PublishedConfigurationsController.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AgileConfig.Server.Application.Configurations;
+using AgileConfig.Server.Apisite.Controllers.api.v2.Models;
+using AgileConfig.Server.Apisite.Filters;
+using AgileConfig.Server.Apisite.Metrics;
+using AgileConfig.Server.Common;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
+
+namespace AgileConfig.Server.Apisite.Controllers.api.v2;
+
+/// <summary>
+///     Published configuration resources consumed by application clients.
+/// </summary>
+[ApiController]
+[Route("api/v2/applications/{applicationId}/environments/{environment}/published-configurations")]
+[TypeFilter(typeof(AppBasicAuthenticationAttribute))]
+[TypeFilter(typeof(V2EnvironmentFilterAttribute))]
+public sealed class PublishedConfigurationsController : ControllerBase
+{
+    private readonly IMeterService _meterService;
+    private readonly IPublishedConfigurationQueryService _publishedConfigurationQueryService;
+
+    public PublishedConfigurationsController(
+        IPublishedConfigurationQueryService publishedConfigurationQueryService,
+        IMeterService meterService)
+    {
+        _publishedConfigurationQueryService = publishedConfigurationQueryService;
+        _meterService = meterService;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IReadOnlyList<PublishedConfigurationResource>>> GetAll(
+        string applicationId,
+        string environment)
+    {
+        var authenticatedApplicationId = Encrypt.UnboxBasicAuth(Request).Item1;
+        if (applicationId != authenticatedApplicationId)
+            return Problem(statusCode: StatusCodes.Status400BadRequest,
+                title: "Application identifier mismatch.",
+                detail: "The route application identifier must match the Basic Authentication username.");
+
+        var result = await _publishedConfigurationQueryService.GetAsync(applicationId, environment);
+        if (!result.Succeeded) return NotFound();
+
+        var timelineId = result.Value.PublishTimelineId;
+        if (!string.IsNullOrEmpty(timelineId))
+        {
+            var etag = $"\"{timelineId}\"";
+            Response.Headers.ETag = etag;
+            Response.Headers.Append("X-Publish-Timeline-Id", timelineId);
+
+            if (Request.Headers.IfNoneMatch == new StringValues(etag)) return StatusCode(StatusCodes.Status304NotModified);
+        }
+
+        _meterService.PullAppConfigCounter?.Add(1,
+            new KeyValuePair<string, object>("appId", applicationId),
+            new KeyValuePair<string, object>("env", environment));
+
+        return Ok(result.Value.Configurations.Select(x => new PublishedConfigurationResource
+        {
+            Id = x.Id,
+            ApplicationId = applicationId,
+            Environment = environment,
+            Group = x.Group,
+            Key = x.Key,
+            Value = x.Value
+        }).ToList());
+    }
+}

--- a/src/AgileConfig.Server.Apisite/Controllers/api/v2/PublishedConfigurationsController.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/api/v2/PublishedConfigurationsController.cs
@@ -8,7 +8,7 @@ using AgileConfig.Server.Apisite.Metrics;
 using AgileConfig.Server.Common;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Primitives;
+using Microsoft.Net.Http.Headers;
 
 namespace AgileConfig.Server.Apisite.Controllers.api.v2;
 
@@ -53,7 +53,7 @@ public sealed class PublishedConfigurationsController : ControllerBase
             Response.Headers.ETag = etag;
             Response.Headers.Append("X-Publish-Timeline-Id", timelineId);
 
-            if (Request.Headers.IfNoneMatch == new StringValues(etag)) return StatusCode(StatusCodes.Status304NotModified);
+            if (MatchesIfNoneMatch(etag)) return StatusCode(StatusCodes.Status304NotModified);
         }
 
         _meterService.PullAppConfigCounter?.Add(1,
@@ -69,5 +69,14 @@ public sealed class PublishedConfigurationsController : ControllerBase
             Key = x.Key,
             Value = x.Value
         }).ToList());
+    }
+
+    private bool MatchesIfNoneMatch(string etag)
+    {
+        if (!EntityTagHeaderValue.TryParseList(Request.Headers.IfNoneMatch.ToArray(), out var validators)) return false;
+
+        var current = new EntityTagHeaderValue(etag);
+        return validators.Any(validator =>
+            validator == EntityTagHeaderValue.Any || validator.Compare(current, useStrongComparison: false));
     }
 }

--- a/src/AgileConfig.Server.Apisite/Controllers/api/v2/ReleasesController.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/api/v2/ReleasesController.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AgileConfig.Server.Application;
+using AgileConfig.Server.Application.Releases;
+using AgileConfig.Server.Apisite.Controllers.api.v2.Models;
+using AgileConfig.Server.Apisite.Filters;
+using AgileConfig.Server.IService;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AgileConfig.Server.Apisite.Controllers.api.v2;
+
+/// <summary>
+///     Version 2 configuration release and rollback resources.
+/// </summary>
+[ApiController]
+[Route("api/v2/applications/{applicationId}/environments/{environment}/releases")]
+[TypeFilter(typeof(AdmBasicAuthenticationAttribute))]
+[TypeFilter(typeof(V2EnvironmentFilterAttribute))]
+public sealed class ReleasesController : ControllerBase
+{
+    private readonly IApplicationManagementService _applicationManagementService;
+    private readonly IReleaseManagementService _releaseManagementService;
+
+    public ReleasesController(
+        IApplicationManagementService applicationManagementService,
+        IReleaseManagementService releaseManagementService)
+    {
+        _applicationManagementService = applicationManagementService;
+        _releaseManagementService = releaseManagementService;
+    }
+
+    [HttpGet]
+    [TypeFilter(typeof(PermissionCheckByBasicAttribute), Arguments = new object[] { Functions.App_Read })]
+    public async Task<ActionResult<IReadOnlyList<ReleaseResource>>> GetAll(string applicationId, string environment)
+    {
+        if (await _applicationManagementService.GetAsync(applicationId) == null) return NotFound();
+
+        var releases = await _releaseManagementService.GetAllAsync(applicationId, environment);
+        return Ok(releases.Select(x => x.ToV2Resource()).ToList());
+    }
+
+    [HttpGet("{releaseId}", Name = RouteNames.Release)]
+    [TypeFilter(typeof(PermissionCheckByBasicAttribute), Arguments = new object[] { Functions.App_Read })]
+    public async Task<ActionResult<ReleaseResource>> GetById(string applicationId, string environment, string releaseId)
+    {
+        var release = await FindRelease(applicationId, environment, releaseId);
+        return release == null ? NotFound() : Ok(release);
+    }
+
+    [HttpPost]
+    [TypeFilter(typeof(PermissionCheckByBasicAttribute), Arguments = new object[] { Functions.Config_Publish })]
+    public async Task<ActionResult<ReleaseResource>> Create(
+        string applicationId,
+        string environment,
+        CreateReleaseRequest request)
+    {
+        var result = await _releaseManagementService.PublishAsync(new PublishConfigurationsCommand(
+            applicationId,
+            request.ConfigurationIds?.ToArray(),
+            request.Log,
+            environment));
+        if (!result.Succeeded) return MapFailure(result.Error, "Configuration release failed.");
+
+        var release = result.Value;
+
+        return CreatedAtRoute(RouteNames.Release, new { applicationId, environment, releaseId = release.Id },
+            release.ToV2Resource());
+    }
+
+    [HttpPost("rollbacks")]
+    [TypeFilter(typeof(PermissionCheckByBasicAttribute), Arguments = new object[] { Functions.Config_Offline })]
+    public async Task<IActionResult> Rollback(
+        string applicationId,
+        string environment,
+        CreateRollbackRequest request)
+    {
+        if (await FindRelease(applicationId, environment, request.ReleaseId) == null) return NotFound();
+
+        var result = await _releaseManagementService.RollbackAsync(
+            new RollbackConfigurationCommand(request.ReleaseId, environment));
+        return result.Succeeded ? NoContent() : MapFailure(result.Error, "Configuration rollback failed.");
+    }
+
+    private async Task<ReleaseResource> FindRelease(string applicationId, string environment, string releaseId)
+    {
+        var release = await _releaseManagementService.GetAsync(applicationId, environment, releaseId);
+        return release?.ToV2Resource();
+    }
+
+    private ObjectResult MapFailure(ApplicationError error, string title)
+    {
+        return error switch
+        {
+            ApplicationError.NotFound => Problem(statusCode: 404, title: "Configuration release not found."),
+            ApplicationError.Conflict => Problem(statusCode: 409, title: "Configuration release conflict."),
+            ApplicationError.ValidationFailed => Problem(statusCode: 400, title: "Invalid release request."),
+            ApplicationError.Forbidden => Problem(statusCode: 403, title: "Configuration release forbidden."),
+            _ => Problem(statusCode: 500, title: title)
+        };
+    }
+}

--- a/src/AgileConfig.Server.Apisite/Controllers/api/v2/ServiceInstancesController.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/api/v2/ServiceInstancesController.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using AgileConfig.Server.Application;
+using AgileConfig.Server.Apisite.Controllers.api.v2.Models;
+using AgileConfig.Server.Apisite.Filters;
+using AgileConfig.Server.Apisite.Models;
+using AgileConfig.Server.Data.Entity;
+using AgileConfig.Server.IService;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AgileConfig.Server.Apisite.Controllers.api.v2;
+
+/// <summary>
+///     Version 2 service registry instance resources.
+/// </summary>
+[ApiController]
+[Route("api/v2/service-instances")]
+public sealed class ServiceInstancesController : ControllerBase
+{
+    private readonly IServiceInstanceManagementService _serviceInstanceManagementService;
+
+    public ServiceInstancesController(
+        IServiceInstanceManagementService serviceInstanceManagementService)
+    {
+        _serviceInstanceManagementService = serviceInstanceManagementService;
+    }
+
+    [HttpGet]
+    [TypeFilter(typeof(AdmBasicAuthenticationAttribute))]
+    [TypeFilter(typeof(PermissionCheckByBasicAttribute), Arguments = new object[] { Functions.Service_Read })]
+    public async Task<ActionResult<IReadOnlyList<ServiceInstanceResource>>> GetAll([FromQuery] ServiceStatus? status)
+    {
+        var instances = await _serviceInstanceManagementService.GetAllAsync(status);
+
+        return Ok(instances.Select(x => x.ToV2Resource()).ToList());
+    }
+
+    [HttpGet("{serviceInstanceId}", Name = RouteNames.ServiceInstance)]
+    [TypeFilter(typeof(AdmBasicAuthenticationAttribute))]
+    [TypeFilter(typeof(PermissionCheckByBasicAttribute), Arguments = new object[] { Functions.Service_Read })]
+    public async Task<ActionResult<ServiceInstanceResource>> GetById(string serviceInstanceId)
+    {
+        var result = await _serviceInstanceManagementService.GetByIdAsync(serviceInstanceId);
+        return result.Succeeded ? Ok(result.Value.ToV2Resource()) : NotFound();
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<ServiceInstanceResource>> Register(RegisterServiceInstanceRequest request)
+    {
+        var result = await _serviceInstanceManagementService.RegisterAsync(new RegisterServiceInstanceCommand(
+            request.ServiceId,
+            request.Name,
+            request.IpAddress,
+            request.Port,
+            JsonSerializer.Serialize(request.Metadata ?? []),
+            request.HealthCheckUrl,
+            request.AlarmUrl,
+            request.HeartbeatMode,
+            RegisterWay.Auto,
+            RejectExisting: false));
+        if (!result.Succeeded) return MapFailure(result.Error, "Service instance registration failed.");
+
+        var resource = result.Value.Instance.ToV2Resource();
+        if (result.Value.WasExisting) return Ok(resource);
+
+        return CreatedAtRoute(RouteNames.ServiceInstance,
+            new { serviceInstanceId = result.Value.UniqueId }, resource);
+    }
+
+    [HttpDelete("{serviceInstanceId}")]
+    [TypeFilter(typeof(AdmBasicAuthenticationAttribute))]
+    [TypeFilter(typeof(PermissionCheckByBasicAttribute), Arguments = new object[] { Functions.Service_Delete })]
+    public async Task<IActionResult> Unregister(string serviceInstanceId)
+    {
+        var result = await _serviceInstanceManagementService.UnregisterAsync(serviceInstanceId);
+        return result.Succeeded ? NoContent() : MapFailure(result.Error, "Service instance could not be unregistered.");
+    }
+
+    [HttpPut("{serviceInstanceId}/heartbeat")]
+    public async Task<ActionResult<HeartbeatResource>> Heartbeat(string serviceInstanceId)
+    {
+        var result = await _serviceInstanceManagementService.ReceiveHeartbeatAsync(serviceInstanceId);
+        if (!result.Succeeded) return NotFound();
+
+        return Ok(new HeartbeatResource
+        {
+            ServiceInstanceId = result.Value.ServiceInstanceId,
+            ReceivedAt = result.Value.ReceivedAt,
+            ServicesVersion = result.Value.ServicesVersion
+        });
+    }
+
+    private ObjectResult MapFailure(ApplicationError error, string title)
+    {
+        return error switch
+        {
+            ApplicationError.NotFound => Problem(statusCode: 404, title: "Service instance not found."),
+            ApplicationError.Conflict => Problem(statusCode: 409, title: "Service instance conflict."),
+            ApplicationError.ValidationFailed => Problem(statusCode: 400, title: "Invalid service instance request."),
+            ApplicationError.Forbidden => Problem(statusCode: 403, title: "Service instance operation forbidden."),
+            _ => Problem(statusCode: 500, title: title)
+        };
+    }
+}

--- a/src/AgileConfig.Server.Apisite/Controllers/api/v2/V2EnvironmentFilterAttribute.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/api/v2/V2EnvironmentFilterAttribute.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using AgileConfig.Server.IService;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace AgileConfig.Server.Apisite.Controllers.api.v2;
+
+public sealed class V2EnvironmentFilterAttribute : IAsyncActionFilter
+{
+    private readonly ISettingService _settingService;
+
+    public V2EnvironmentFilterAttribute(ISettingService settingService)
+    {
+        _settingService = settingService;
+    }
+
+    public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        context.ActionArguments.TryGetValue("environment", out var value);
+        var environment = value as string;
+        var configuredEnvironment = (await _settingService.GetEnvironmentList())
+            .FirstOrDefault(x => string.Equals(x, environment, StringComparison.OrdinalIgnoreCase));
+
+        if (configuredEnvironment == null)
+        {
+            var problem = new ProblemDetails
+            {
+                Status = StatusCodes.Status400BadRequest,
+                Title = "Unknown environment.",
+                Detail = $"The environment '{environment}' is not configured."
+            };
+            var result = new ObjectResult(problem) { StatusCode = problem.Status };
+            result.ContentTypes.Add("application/problem+json");
+            context.Result = result;
+            return;
+        }
+
+        context.ActionArguments["environment"] = configuredEnvironment;
+        await next();
+    }
+}

--- a/src/AgileConfig.Server.Apisite/Startup.cs
+++ b/src/AgileConfig.Server.Apisite/Startup.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Net;
 using AgileConfig.Server.Apisite.UIExtension;
 using AgileConfig.Server.Apisite.Websocket;
+using AgileConfig.Server.Apisite.Application;
+using AgileConfig.Server.Application;
 using AgileConfig.Server.Common;
 using AgileConfig.Server.Common.EventBus;
 using AgileConfig.Server.Common.RestClient;
@@ -57,6 +59,7 @@ public class Startup
         services.AddRestClient();
 
         services.AddMemoryCache();
+        services.AddHttpContextAccessor();
 
         services.AddCors();
         services.AddMvc().AddRazorRuntimeCompilation().AddControllersAsServices();
@@ -71,6 +74,9 @@ public class Startup
         services.AddRepositories();
 
         services.AddBusinessServices();
+        services.AddApplicationServices();
+        services.AddScoped<ICurrentUserAccessor, HttpCurrentUserAccessor>();
+        services.AddSingleton<IPreviewModeAccessor, AppsettingsPreviewModeAccessor>();
 
         services.ConfigureOptions<ConfigureJwtBearerOptions>();
         services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)

--- a/src/AgileConfig.Server.Apisite/Startup.cs
+++ b/src/AgileConfig.Server.Apisite/Startup.cs
@@ -148,7 +148,14 @@ public class Startup
     {
         services.AddSwaggerGen(c =>
         {
-            c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
+            c.SwaggerDoc("v1", new OpenApiInfo { Title = "AgileConfig API", Version = "v1" });
+            c.SwaggerDoc("v2", new OpenApiInfo { Title = "AgileConfig API", Version = "v2" });
+            c.DocInclusionPredicate((documentName, apiDescription) =>
+            {
+                var path = apiDescription.RelativePath ?? string.Empty;
+                var isV2 = path.StartsWith("api/v2/", StringComparison.OrdinalIgnoreCase);
+                return documentName == (isV2 ? "v2" : "v1");
+            });
             var basePath = Path.GetDirectoryName(typeof(Program).Assembly.Location);
             var xmlPath = Path.Combine(basePath, "AgileConfig.Server.Apisite.xml");
             c.IncludeXmlComments(xmlPath);
@@ -158,6 +165,10 @@ public class Startup
     private void AddSwaggerMiddleWare(IApplicationBuilder app)
     {
         app.UseSwagger();
-        app.UseSwaggerUI(c => { c.SwaggerEndpoint("v1/swagger.json", "My API V1"); });
+        app.UseSwaggerUI(c =>
+        {
+            c.SwaggerEndpoint("v2/swagger.json", "AgileConfig API V2");
+            c.SwaggerEndpoint("v1/swagger.json", "AgileConfig API V1");
+        });
     }
 }

--- a/src/AgileConfig.Server.Application/AgileConfig.Server.Application.csproj
+++ b/src/AgileConfig.Server.Application/AgileConfig.Server.Application.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AgileConfig.Server.Common\AgileConfig.Server.Common.csproj" />
+    <ProjectReference Include="..\AgileConfig.Server.Data.Entity\AgileConfig.Server.Data.Entity.csproj" />
+    <ProjectReference Include="..\AgileConfig.Server.Event\AgileConfig.Server.Event.csproj" />
+    <ProjectReference Include="..\AgileConfig.Server.IService\AgileConfig.Server.IService.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/AgileConfig.Server.Application/ApplicationError.cs
+++ b/src/AgileConfig.Server.Application/ApplicationError.cs
@@ -1,0 +1,11 @@
+namespace AgileConfig.Server.Application;
+
+public enum ApplicationError
+{
+    None,
+    NotFound,
+    Conflict,
+    Forbidden,
+    ValidationFailed,
+    OperationFailed
+}

--- a/src/AgileConfig.Server.Application/ApplicationManagement.cs
+++ b/src/AgileConfig.Server.Application/ApplicationManagement.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AgileConfig.Server.Data.Entity;
+
+namespace AgileConfig.Server.Application;
+
+public interface IApplicationManagementService
+{
+    Task<IReadOnlyList<ApplicationDetails>> GetAllAsync();
+
+    Task<ApplicationDetails> GetAsync(string applicationId);
+
+    Task<ApplicationResult<App>> CreateAsync(CreateApplicationCommand command);
+
+    Task<ApplicationResult<App>> UpdateAsync(UpdateApplicationCommand command);
+
+    Task<ApplicationResult<App>> DeleteAsync(DeleteApplicationCommand command);
+}
+
+public sealed record ApplicationDetails(App Application, IReadOnlyList<string> InheritedApplicationIds);
+
+public sealed record CreateApplicationCommand(
+    string Id,
+    string Name,
+    string Group,
+    string Secret,
+    bool Enabled,
+    bool IsInheritanceSource,
+    IReadOnlyList<string> InheritsFrom);
+
+public sealed record UpdateApplicationCommand(
+    string Id,
+    string Name,
+    string Group,
+    string Secret,
+    bool Enabled,
+    bool IsInheritanceSource,
+    IReadOnlyList<string> InheritsFrom);
+
+public sealed record DeleteApplicationCommand(string Id);

--- a/src/AgileConfig.Server.Application/ApplicationManagement.cs
+++ b/src/AgileConfig.Server.Application/ApplicationManagement.cs
@@ -26,7 +26,8 @@ public sealed record CreateApplicationCommand(
     string Secret,
     bool Enabled,
     bool IsInheritanceSource,
-    IReadOnlyList<string> InheritsFrom);
+    IReadOnlyList<string> InheritsFrom,
+    bool ValidateInheritanceReferences = false);
 
 public sealed record UpdateApplicationCommand(
     string Id,
@@ -35,6 +36,7 @@ public sealed record UpdateApplicationCommand(
     string Secret,
     bool Enabled,
     bool IsInheritanceSource,
-    IReadOnlyList<string> InheritsFrom);
+    IReadOnlyList<string> InheritsFrom,
+    bool ValidateInheritanceReferences = false);
 
 public sealed record DeleteApplicationCommand(string Id);

--- a/src/AgileConfig.Server.Application/ApplicationManagementService.cs
+++ b/src/AgileConfig.Server.Application/ApplicationManagementService.cs
@@ -56,6 +56,10 @@ public sealed class ApplicationManagementService : IApplicationManagementService
         if (await _appService.GetAsync(command.Id) != null)
             return ApplicationResult<App>.Failure(ApplicationError.Conflict);
 
+        if (command.ValidateInheritanceReferences &&
+            !await HasValidInheritanceReferencesAsync(command.Id, command.IsInheritanceSource, command.InheritsFrom))
+            return ApplicationResult<App>.Failure(ApplicationError.ValidationFailed);
+
         var app = new App
         {
             Id = command.Id,
@@ -83,6 +87,10 @@ public sealed class ApplicationManagementService : IApplicationManagementService
         if (app == null) return ApplicationResult<App>.Failure(ApplicationError.NotFound);
 
         if (_previewModeAccessor.IsPreviewMode && app.Name == "test_app")
+            return ApplicationResult<App>.Failure(ApplicationError.ValidationFailed);
+
+        if (command.ValidateInheritanceReferences &&
+            !await HasValidInheritanceReferencesAsync(command.Id, command.IsInheritanceSource, command.InheritsFrom))
             return ApplicationResult<App>.Failure(ApplicationError.ValidationFailed);
 
         app.Name = command.Name;
@@ -130,6 +138,29 @@ public sealed class ApplicationManagementService : IApplicationManagementService
     {
         var userId = await _currentUserAccessor.GetUserIdAsync();
         return string.IsNullOrWhiteSpace(userId) ? null : userId;
+    }
+
+    private async Task<bool> HasValidInheritanceReferencesAsync(
+        string applicationId,
+        bool isInheritanceSource,
+        IReadOnlyList<string> inheritedAppIds)
+    {
+        if (isInheritanceSource || inheritedAppIds == null || inheritedAppIds.Count == 0) return true;
+
+        var distinctIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var inheritedAppId in inheritedAppIds)
+        {
+            if (string.IsNullOrWhiteSpace(inheritedAppId) ||
+                inheritedAppId.Length > 36 ||
+                !distinctIds.Add(inheritedAppId) ||
+                string.Equals(applicationId, inheritedAppId, StringComparison.Ordinal))
+                return false;
+
+            var inheritedApp = await _appService.GetAsync(inheritedAppId);
+            if (inheritedApp?.Type != AppType.Inheritance) return false;
+        }
+
+        return true;
     }
 
     private static List<AppInheritanced> BuildInheritanceApps(

--- a/src/AgileConfig.Server.Application/ApplicationManagementService.cs
+++ b/src/AgileConfig.Server.Application/ApplicationManagementService.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AgileConfig.Server.Common.EventBus;
+using AgileConfig.Server.Data.Entity;
+using AgileConfig.Server.Event;
+using AgileConfig.Server.IService;
+
+namespace AgileConfig.Server.Application;
+
+public sealed class ApplicationManagementService : IApplicationManagementService
+{
+    private readonly IAppService _appService;
+    private readonly ICurrentUserAccessor _currentUserAccessor;
+    private readonly ITinyEventBus _eventBus;
+    private readonly IPreviewModeAccessor _previewModeAccessor;
+    private readonly TimeProvider _timeProvider;
+
+    public ApplicationManagementService(
+        IAppService appService,
+        ITinyEventBus eventBus,
+        ICurrentUserAccessor currentUserAccessor,
+        TimeProvider timeProvider,
+        IPreviewModeAccessor previewModeAccessor)
+    {
+        _appService = appService ?? throw new ArgumentNullException(nameof(appService));
+        _eventBus = eventBus ?? throw new ArgumentNullException(nameof(eventBus));
+        _currentUserAccessor = currentUserAccessor ?? throw new ArgumentNullException(nameof(currentUserAccessor));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _previewModeAccessor = previewModeAccessor ?? throw new ArgumentNullException(nameof(previewModeAccessor));
+    }
+
+    public async Task<IReadOnlyList<ApplicationDetails>> GetAllAsync()
+    {
+        var applications = await _appService.GetAllAppsAsync();
+        var result = new List<ApplicationDetails>(applications.Count);
+        foreach (var application in applications)
+        {
+            result.Add(await BuildDetailsAsync(application));
+        }
+
+        return result;
+    }
+
+    public async Task<ApplicationDetails> GetAsync(string applicationId)
+    {
+        var application = await _appService.GetAsync(applicationId);
+        return application == null ? null : await BuildDetailsAsync(application);
+    }
+
+    public async Task<ApplicationResult<App>> CreateAsync(CreateApplicationCommand command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (await _appService.GetAsync(command.Id) != null)
+            return ApplicationResult<App>.Failure(ApplicationError.Conflict);
+
+        var app = new App
+        {
+            Id = command.Id,
+            Name = command.Name,
+            Group = command.Group,
+            Secret = command.Secret,
+            Enabled = command.Enabled,
+            Type = command.IsInheritanceSource ? AppType.Inheritance : AppType.PRIVATE,
+            CreateTime = GetLocalNow(),
+            Creator = await GetCurrentUserIdAsync()
+        };
+
+        var inheritanceApps = BuildInheritanceApps(app.Id, command.IsInheritanceSource, command.InheritsFrom);
+        var succeeded = await _appService.AddAsync(app, inheritanceApps);
+        if (!succeeded) return ApplicationResult<App>.Failure(ApplicationError.OperationFailed, app);
+
+        return ApplicationResult<App>.Success(app);
+    }
+
+    public async Task<ApplicationResult<App>> UpdateAsync(UpdateApplicationCommand command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var app = await _appService.GetAsync(command.Id);
+        if (app == null) return ApplicationResult<App>.Failure(ApplicationError.NotFound);
+
+        if (_previewModeAccessor.IsPreviewMode && app.Name == "test_app")
+            return ApplicationResult<App>.Failure(ApplicationError.ValidationFailed);
+
+        app.Name = command.Name;
+        app.Group = command.Group;
+        app.Secret = command.Secret;
+        app.Enabled = command.Enabled;
+        app.Type = command.IsInheritanceSource ? AppType.Inheritance : AppType.PRIVATE;
+        app.UpdateTime = GetLocalNow();
+
+        var inheritanceApps = BuildInheritanceApps(app.Id, command.IsInheritanceSource, command.InheritsFrom);
+        var succeeded = await _appService.UpdateAsync(app, inheritanceApps);
+        if (!succeeded) return ApplicationResult<App>.Failure(ApplicationError.OperationFailed);
+
+        return ApplicationResult<App>.Success(app);
+    }
+
+    public async Task<ApplicationResult<App>> DeleteAsync(DeleteApplicationCommand command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var app = await _appService.GetAsync(command.Id);
+        if (app == null) return ApplicationResult<App>.Failure(ApplicationError.NotFound);
+
+        var succeeded = await _appService.DeleteAsync(app);
+        if (!succeeded) return ApplicationResult<App>.Failure(ApplicationError.OperationFailed);
+
+        _eventBus.Fire(new DeleteAppSuccessful(app, _currentUserAccessor.UserName));
+        return ApplicationResult<App>.Success(app);
+    }
+
+    private DateTime GetLocalNow()
+    {
+        return _timeProvider.GetLocalNow().DateTime;
+    }
+
+    private async Task<ApplicationDetails> BuildDetailsAsync(App application)
+    {
+        var inheritedApplications = await _appService.GetInheritancedAppsAsync(application.Id);
+        return new ApplicationDetails(
+            application,
+            inheritedApplications.Select(x => x.Id).ToList());
+    }
+
+    private async Task<string> GetCurrentUserIdAsync()
+    {
+        var userId = await _currentUserAccessor.GetUserIdAsync();
+        return string.IsNullOrWhiteSpace(userId) ? null : userId;
+    }
+
+    private static List<AppInheritanced> BuildInheritanceApps(
+        string appId,
+        bool isInheritanceSource,
+        IReadOnlyList<string> inheritedAppIds)
+    {
+        if (isInheritanceSource || inheritedAppIds == null) return [];
+
+        return inheritedAppIds
+            .Select((inheritedAppId, index) => new AppInheritanced
+            {
+                Id = Guid.NewGuid().ToString("N"),
+                AppId = appId,
+                InheritancedAppId = inheritedAppId,
+                Sort = index
+            })
+            .ToList();
+    }
+}

--- a/src/AgileConfig.Server.Application/ApplicationResult.cs
+++ b/src/AgileConfig.Server.Application/ApplicationResult.cs
@@ -1,0 +1,55 @@
+namespace AgileConfig.Server.Application;
+
+public sealed class ApplicationResult
+{
+    private ApplicationResult(bool succeeded, ApplicationError error)
+    {
+        Succeeded = succeeded;
+        Error = error;
+    }
+
+    public bool Succeeded { get; }
+
+    public ApplicationError Error { get; }
+
+    public static ApplicationResult Success()
+    {
+        return new ApplicationResult(true, ApplicationError.None);
+    }
+
+    public static ApplicationResult Failure(ApplicationError error)
+    {
+        return new ApplicationResult(false, error);
+    }
+}
+
+public sealed class ApplicationResult<T>
+{
+    private ApplicationResult(bool succeeded, T value, ApplicationError error)
+    {
+        Succeeded = succeeded;
+        Value = value;
+        Error = error;
+    }
+
+    public bool Succeeded { get; }
+
+    public T Value { get; }
+
+    public ApplicationError Error { get; }
+
+    public static ApplicationResult<T> Success(T value)
+    {
+        return new ApplicationResult<T>(true, value, ApplicationError.None);
+    }
+
+    public static ApplicationResult<T> Failure(ApplicationError error)
+    {
+        return new ApplicationResult<T>(false, default, error);
+    }
+
+    public static ApplicationResult<T> Failure(ApplicationError error, T value)
+    {
+        return new ApplicationResult<T>(false, value, error);
+    }
+}

--- a/src/AgileConfig.Server.Application/Configurations/ConfigurationManagementContracts.cs
+++ b/src/AgileConfig.Server.Application/Configurations/ConfigurationManagementContracts.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AgileConfig.Server.Data.Entity;
+
+namespace AgileConfig.Server.Application.Configurations;
+
+public sealed record CreateConfigurationCommand(
+    string Id,
+    string ApplicationId,
+    string Group,
+    string Key,
+    string Value,
+    string Description,
+    string Environment);
+
+public sealed record UpdateConfigurationCommand(
+    string Id,
+    string ApplicationId,
+    string Group,
+    string Key,
+    string Value,
+    string Description,
+    string Environment);
+
+public sealed record DeleteConfigurationCommand(string Id, string Environment);
+
+public interface IConfigurationManagementService
+{
+    Task<ApplicationResult<Config>> CreateAsync(CreateConfigurationCommand command);
+
+    Task<ApplicationResult<Config>> UpdateAsync(UpdateConfigurationCommand command);
+
+    Task<ApplicationResult<Config>> DeleteAsync(DeleteConfigurationCommand command);
+
+    Task<IReadOnlyList<Config>> GetAllAsync(string applicationId, string environment);
+
+    Task<Config> GetAsync(string applicationId, string environment, string configurationId);
+}

--- a/src/AgileConfig.Server.Application/Configurations/ConfigurationManagementService.cs
+++ b/src/AgileConfig.Server.Application/Configurations/ConfigurationManagementService.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AgileConfig.Server.Common;
+using AgileConfig.Server.Common.EventBus;
+using AgileConfig.Server.Data.Entity;
+using AgileConfig.Server.Event;
+using AgileConfig.Server.IService;
+
+namespace AgileConfig.Server.Application.Configurations;
+
+public sealed class ConfigurationManagementService : IConfigurationManagementService
+{
+    private readonly IAppService _appService;
+    private readonly IConfigService _configService;
+    private readonly ICurrentUserAccessor _currentUserAccessor;
+    private readonly ITinyEventBus _eventBus;
+    private readonly TimeProvider _timeProvider;
+
+    public ConfigurationManagementService(
+        IAppService appService,
+        IConfigService configService,
+        ICurrentUserAccessor currentUserAccessor,
+        ITinyEventBus eventBus,
+        TimeProvider timeProvider)
+    {
+        _appService = appService;
+        _configService = configService;
+        _currentUserAccessor = currentUserAccessor;
+        _eventBus = eventBus;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task<ApplicationResult<Config>> CreateAsync(CreateConfigurationCommand command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (await _appService.GetAsync(command.ApplicationId) == null)
+            return ApplicationResult<Config>.Failure(ApplicationError.NotFound);
+
+        var existing = await _configService.GetByAppIdKeyEnv(
+            command.ApplicationId,
+            command.Group,
+            command.Key,
+            command.Environment);
+        if (existing != null) return ApplicationResult<Config>.Failure(ApplicationError.Conflict);
+
+        var config = new Config
+        {
+            Id = string.IsNullOrEmpty(command.Id) ? Guid.NewGuid().ToString("N") : command.Id,
+            Key = command.Key,
+            AppId = command.ApplicationId,
+            Description = command.Description,
+            Value = command.Value,
+            Group = command.Group,
+            Status = ConfigStatus.Enabled,
+            CreateTime = _timeProvider.GetLocalNow().DateTime,
+            UpdateTime = null,
+            OnlineStatus = OnlineStatus.WaitPublish,
+            EditStatus = EditStatus.Add,
+            Env = command.Environment
+        };
+
+        var persisted = await _configService.AddAsync(config, command.Environment);
+        if (!persisted) return ApplicationResult<Config>.Failure(ApplicationError.OperationFailed, config);
+
+        _eventBus.Fire(new AddConfigSuccessful(config, _currentUserAccessor.UserName));
+        return ApplicationResult<Config>.Success(config);
+    }
+
+    public async Task<ApplicationResult<Config>> UpdateAsync(UpdateConfigurationCommand command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var config = await _configService.GetAsync(command.Id, command.Environment);
+        if (config == null) return ApplicationResult<Config>.Failure(ApplicationError.NotFound);
+
+        // Preserve the legacy endpoint's application ownership check. The old API
+        // treats an application with no editable configurations as nonexistent.
+        var applicationConfigs = await _configService.GetByAppIdAsync(
+            command.ApplicationId,
+            command.Environment);
+        if (!applicationConfigs.Any()) return ApplicationResult<Config>.Failure(ApplicationError.NotFound);
+
+        var oldConfig = new Config
+        {
+            Key = config.Key,
+            Group = config.Group,
+            Value = config.Value
+        };
+        if (config.Group != command.Group || config.Key != command.Key)
+        {
+            var conflicting = await _configService.GetByAppIdKeyEnv(
+                command.ApplicationId,
+                command.Group,
+                command.Key,
+                command.Environment);
+            if (conflicting != null) return ApplicationResult<Config>.Failure(ApplicationError.Conflict);
+        }
+
+        config.AppId = command.ApplicationId;
+        config.Description = command.Description;
+        config.Key = command.Key;
+        config.Value = command.Value;
+        config.Group = command.Group;
+        config.UpdateTime = _timeProvider.GetLocalNow().DateTime;
+        config.Env = command.Environment;
+
+        if (!IsOnlyUpdateDescription(config, oldConfig))
+        {
+            var isPublished = await _configService.IsPublishedAsync(config.Id, command.Environment);
+            config.EditStatus = isPublished ? EditStatus.Edit : EditStatus.Add;
+            config.OnlineStatus = OnlineStatus.WaitPublish;
+        }
+
+        var persisted = await _configService.UpdateAsync(config, command.Environment);
+        if (!persisted) return ApplicationResult<Config>.Failure(ApplicationError.OperationFailed);
+
+        _eventBus.Fire(new EditConfigSuccessful(config, _currentUserAccessor.UserName));
+        return ApplicationResult<Config>.Success(config);
+    }
+
+    public async Task<ApplicationResult<Config>> DeleteAsync(DeleteConfigurationCommand command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var config = await _configService.GetAsync(command.Id, command.Environment);
+        if (config == null) return ApplicationResult<Config>.Failure(ApplicationError.NotFound);
+
+        config.EditStatus = EditStatus.Deleted;
+        config.OnlineStatus = OnlineStatus.WaitPublish;
+
+        var isPublished = await _configService.IsPublishedAsync(config.Id, command.Environment);
+        if (!isPublished) config.Status = ConfigStatus.Deleted;
+
+        var persisted = await _configService.UpdateAsync(config, command.Environment);
+        if (!persisted) return ApplicationResult<Config>.Failure(ApplicationError.OperationFailed);
+
+        _eventBus.Fire(new DeleteConfigSuccessful(config, _currentUserAccessor.UserName));
+        return ApplicationResult<Config>.Success(config);
+    }
+
+    public async Task<IReadOnlyList<Config>> GetAllAsync(string applicationId, string environment)
+    {
+        var configs = await _configService.GetByAppIdAsync(applicationId, environment);
+        return configs
+            .Where(x => x.Status != ConfigStatus.Deleted && x.EditStatus != EditStatus.Deleted)
+            .ToList();
+    }
+
+    public async Task<Config> GetAsync(string applicationId, string environment, string configurationId)
+    {
+        var config = await _configService.GetAsync(configurationId, environment);
+        if (config == null || config.AppId != applicationId ||
+            config.Status == ConfigStatus.Deleted || config.EditStatus == EditStatus.Deleted)
+            return null;
+
+        return config;
+    }
+
+    private static bool IsOnlyUpdateDescription(Config newConfig, Config oldConfig)
+    {
+        return newConfig.Key == oldConfig.Key &&
+               newConfig.Group == oldConfig.Group &&
+               newConfig.Value == oldConfig.Value;
+    }
+}

--- a/src/AgileConfig.Server.Application/Configurations/PublishedConfigurationQueryService.cs
+++ b/src/AgileConfig.Server.Application/Configurations/PublishedConfigurationQueryService.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AgileConfig.Server.Data.Entity;
+using AgileConfig.Server.IService;
+
+namespace AgileConfig.Server.Application.Configurations;
+
+public interface IPublishedConfigurationQueryService
+{
+    Task<ApplicationResult<PublishedConfigurationSnapshot>> GetAsync(
+        string applicationId,
+        string environment);
+}
+
+public sealed record PublishedConfigurationSnapshot(
+    string PublishTimelineId,
+    IReadOnlyList<Config> Configurations);
+
+public sealed class PublishedConfigurationQueryService : IPublishedConfigurationQueryService
+{
+    private readonly IAppService _appService;
+    private readonly IConfigService _configService;
+
+    public PublishedConfigurationQueryService(IAppService appService, IConfigService configService)
+    {
+        _appService = appService ?? throw new ArgumentNullException(nameof(appService));
+        _configService = configService ?? throw new ArgumentNullException(nameof(configService));
+    }
+
+    public async Task<ApplicationResult<PublishedConfigurationSnapshot>> GetAsync(
+        string applicationId,
+        string environment)
+    {
+        var application = await _appService.GetAsync(applicationId);
+        if (application == null || !application.Enabled)
+            return ApplicationResult<PublishedConfigurationSnapshot>.Failure(ApplicationError.NotFound);
+
+        var timelineId = await _configService.GetLastPublishTimelineVirtualIdAsyncWithCache(
+            applicationId,
+            environment);
+        var configurations = await _configService.GetPublishedConfigsByAppIdWithInheritance(
+            applicationId,
+            environment);
+
+        return ApplicationResult<PublishedConfigurationSnapshot>.Success(
+            new PublishedConfigurationSnapshot(timelineId, configurations));
+    }
+}

--- a/src/AgileConfig.Server.Application/ICurrentUserAccessor.cs
+++ b/src/AgileConfig.Server.Application/ICurrentUserAccessor.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+
+namespace AgileConfig.Server.Application;
+
+public interface ICurrentUserAccessor
+{
+    string UserName { get; }
+
+    Task<string> GetUserIdAsync();
+}

--- a/src/AgileConfig.Server.Application/Nodes/NodeManagementModels.cs
+++ b/src/AgileConfig.Server.Application/Nodes/NodeManagementModels.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using AgileConfig.Server.Data.Entity;
+
+namespace AgileConfig.Server.Application;
+
+public sealed record CreateNodeCommand(string Address, string Remark);
+
+public interface INodeManagementService
+{
+    Task<IReadOnlyList<ServerNode>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    Task<ServerNode> GetByAddressAsync(string address, CancellationToken cancellationToken = default);
+
+    Task<ApplicationResult<ServerNode>> CreateAsync(
+        CreateNodeCommand command,
+        CancellationToken cancellationToken = default);
+
+    Task<ApplicationResult> DeleteAsync(
+        string address,
+        CancellationToken cancellationToken = default);
+}
+
+public interface IPreviewModeAccessor
+{
+    bool IsPreviewMode { get; }
+}

--- a/src/AgileConfig.Server.Application/Nodes/NodeManagementService.cs
+++ b/src/AgileConfig.Server.Application/Nodes/NodeManagementService.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AgileConfig.Server.Common.EventBus;
+using AgileConfig.Server.Data.Entity;
+using AgileConfig.Server.Event;
+using AgileConfig.Server.IService;
+
+namespace AgileConfig.Server.Application;
+
+public sealed class NodeManagementService : INodeManagementService
+{
+    private readonly ICurrentUserAccessor _currentUserAccessor;
+    private readonly IPreviewModeAccessor _previewModeAccessor;
+    private readonly IRemoteServerNodeProxy _remoteServerNodeProxy;
+    private readonly IServerNodeService _serverNodeService;
+    private readonly ITinyEventBus _tinyEventBus;
+    private readonly TimeProvider _timeProvider;
+
+    public NodeManagementService(
+        IServerNodeService serverNodeService,
+        IRemoteServerNodeProxy remoteServerNodeProxy,
+        ITinyEventBus tinyEventBus,
+        ICurrentUserAccessor currentUserAccessor,
+        IPreviewModeAccessor previewModeAccessor,
+        TimeProvider timeProvider)
+    {
+        _serverNodeService = serverNodeService;
+        _remoteServerNodeProxy = remoteServerNodeProxy;
+        _tinyEventBus = tinyEventBus;
+        _currentUserAccessor = currentUserAccessor;
+        _previewModeAccessor = previewModeAccessor;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task<IReadOnlyList<ServerNode>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var nodes = await _serverNodeService.GetAllNodesAsync();
+        return nodes.OrderBy(x => x.CreateTime).ToList();
+    }
+
+    public Task<ServerNode> GetByAddressAsync(string address, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return _serverNodeService.GetAsync(NormalizeAddress(address));
+    }
+
+    public async Task<ApplicationResult<ServerNode>> CreateAsync(
+        CreateNodeCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        if (command == null) return ApplicationResult<ServerNode>.Failure(ApplicationError.ValidationFailed);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var address = NormalizeAddress(command.Address);
+        if (string.IsNullOrWhiteSpace(address))
+            return ApplicationResult<ServerNode>.Failure(ApplicationError.ValidationFailed);
+
+        var oldNode = await _serverNodeService.GetAsync(address);
+        if (oldNode != null)
+            return ApplicationResult<ServerNode>.Failure(ApplicationError.Conflict);
+
+        var node = new ServerNode
+        {
+            Id = address,
+            Remark = command.Remark,
+            Status = NodeStatus.Offline,
+            CreateTime = _timeProvider.GetLocalNow().DateTime
+        };
+
+        var added = await _serverNodeService.AddAsync(node);
+        if (!added) return ApplicationResult<ServerNode>.Failure(ApplicationError.OperationFailed, node);
+
+        _tinyEventBus.Fire(new AddNodeSuccessful(node, _currentUserAccessor.UserName));
+        await _remoteServerNodeProxy.TestEchoAsync(node.Id);
+
+        return ApplicationResult<ServerNode>.Success(node);
+    }
+
+    public async Task<ApplicationResult> DeleteAsync(
+        string address,
+        CancellationToken cancellationToken = default)
+    {
+        if (_previewModeAccessor.IsPreviewMode)
+            return ApplicationResult.Failure(ApplicationError.Forbidden);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var normalizedAddress = NormalizeAddress(address);
+        var node = string.IsNullOrWhiteSpace(normalizedAddress)
+            ? null
+            : await _serverNodeService.GetAsync(normalizedAddress);
+        if (node == null) return ApplicationResult.Failure(ApplicationError.NotFound);
+
+        var deleted = await _serverNodeService.DeleteAsync(node);
+        if (!deleted) return ApplicationResult.Failure(ApplicationError.OperationFailed);
+
+        _tinyEventBus.Fire(new DeleteNodeSuccessful(node, _currentUserAccessor.UserName));
+        return ApplicationResult.Success();
+    }
+
+    private static string NormalizeAddress(string address)
+    {
+        return address?.TrimEnd('/');
+    }
+}

--- a/src/AgileConfig.Server.Application/Releases/ReleaseManagementContracts.cs
+++ b/src/AgileConfig.Server.Application/Releases/ReleaseManagementContracts.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AgileConfig.Server.Data.Entity;
+
+namespace AgileConfig.Server.Application.Releases;
+
+public sealed record PublishConfigurationsCommand(
+    string ApplicationId,
+    string[] ConfigurationIds,
+    string Log,
+    string Environment);
+
+public sealed record RollbackConfigurationCommand(string ReleaseId, string Environment);
+
+public interface IReleaseManagementService
+{
+    Task<IReadOnlyList<PublishTimeline>> GetAllAsync(string applicationId, string environment);
+
+    Task<PublishTimeline> GetAsync(string applicationId, string environment, string releaseId);
+
+    Task<ApplicationResult<PublishTimeline>> PublishAsync(PublishConfigurationsCommand command);
+
+    Task<ApplicationResult<PublishTimeline>> RollbackAsync(RollbackConfigurationCommand command);
+}

--- a/src/AgileConfig.Server.Application/Releases/ReleaseManagementService.cs
+++ b/src/AgileConfig.Server.Application/Releases/ReleaseManagementService.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AgileConfig.Server.Common.EventBus;
+using AgileConfig.Server.Data.Entity;
+using AgileConfig.Server.Event;
+using AgileConfig.Server.IService;
+
+namespace AgileConfig.Server.Application.Releases;
+
+public sealed class ReleaseManagementService : IReleaseManagementService
+{
+    private readonly IAppService _appService;
+    private readonly IConfigService _configService;
+    private readonly ICurrentUserAccessor _currentUserAccessor;
+    private readonly ITinyEventBus _eventBus;
+    private readonly TimeProvider _timeProvider;
+
+    public ReleaseManagementService(
+        IAppService appService,
+        IConfigService configService,
+        ICurrentUserAccessor currentUserAccessor,
+        ITinyEventBus eventBus,
+        TimeProvider timeProvider)
+    {
+        _appService = appService;
+        _configService = configService;
+        _currentUserAccessor = currentUserAccessor;
+        _eventBus = eventBus;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task<IReadOnlyList<PublishTimeline>> GetAllAsync(string applicationId, string environment)
+    {
+        var releases = await _configService.GetPublishTimelineHistoryAsync(applicationId, environment);
+        return releases.OrderByDescending(x => x.Version).ToList();
+    }
+
+    public async Task<PublishTimeline> GetAsync(string applicationId, string environment, string releaseId)
+    {
+        var release = await _configService.GetPublishTimeLineNodeAsync(releaseId, environment);
+        return release?.AppId == applicationId ? release : null;
+    }
+
+    public async Task<ApplicationResult<PublishTimeline>> PublishAsync(PublishConfigurationsCommand command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (await _appService.GetAsync(command.ApplicationId) == null)
+            return ApplicationResult<PublishTimeline>.Failure(ApplicationError.NotFound);
+
+        var userId = await _currentUserAccessor.GetUserIdAsync();
+        var result = await _configService.Publish(
+            command.ApplicationId,
+            command.ConfigurationIds,
+            command.Log,
+            userId,
+            command.Environment);
+        if (!result.result) return ApplicationResult<PublishTimeline>.Failure(ApplicationError.OperationFailed);
+
+        var timeline = await _configService.GetPublishTimeLineNodeAsync(
+            result.publishTimelineId,
+            command.Environment);
+        timeline ??= new PublishTimeline
+        {
+            Id = result.publishTimelineId,
+            AppId = command.ApplicationId,
+            Env = command.Environment,
+            Log = command.Log,
+            PublishUserId = userId,
+            PublishTime = _timeProvider.GetLocalNow().DateTime
+        };
+
+        _eventBus.Fire(new PublishConfigSuccessful(timeline, _currentUserAccessor.UserName));
+        return ApplicationResult<PublishTimeline>.Success(timeline);
+    }
+
+    public async Task<ApplicationResult<PublishTimeline>> RollbackAsync(RollbackConfigurationCommand command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var timeline = await _configService.GetPublishTimeLineNodeAsync(command.ReleaseId, command.Environment);
+        if (timeline == null) return ApplicationResult<PublishTimeline>.Failure(ApplicationError.NotFound);
+
+        var result = await _configService.RollbackAsync(command.ReleaseId, command.Environment);
+        if (!result) return ApplicationResult<PublishTimeline>.Failure(ApplicationError.OperationFailed);
+
+        _eventBus.Fire(new RollbackConfigSuccessful(timeline, _currentUserAccessor.UserName));
+        return ApplicationResult<PublishTimeline>.Success(timeline);
+    }
+}

--- a/src/AgileConfig.Server.Application/ServiceCollectionExt.cs
+++ b/src/AgileConfig.Server.Application/ServiceCollectionExt.cs
@@ -1,0 +1,21 @@
+using System;
+using AgileConfig.Server.Application.Configurations;
+using AgileConfig.Server.Application.Releases;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AgileConfig.Server.Application;
+
+public static class ServiceCollectionExt
+{
+    public static IServiceCollection AddApplicationServices(this IServiceCollection services)
+    {
+        services.AddSingleton(TimeProvider.System);
+        services.AddScoped<IApplicationManagementService, ApplicationManagementService>();
+        services.AddScoped<IConfigurationManagementService, ConfigurationManagementService>();
+        services.AddScoped<IPublishedConfigurationQueryService, PublishedConfigurationQueryService>();
+        services.AddScoped<IReleaseManagementService, ReleaseManagementService>();
+        services.AddScoped<INodeManagementService, NodeManagementService>();
+        services.AddScoped<IServiceInstanceManagementService, ServiceInstanceManagementService>();
+        return services;
+    }
+}

--- a/src/AgileConfig.Server.Application/ServiceInstances/ServiceInstanceManagementModels.cs
+++ b/src/AgileConfig.Server.Application/ServiceInstances/ServiceInstanceManagementModels.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using AgileConfig.Server.Data.Entity;
+
+namespace AgileConfig.Server.Application;
+
+public sealed record RegisterServiceInstanceCommand(
+    string ServiceId,
+    string ServiceName,
+    string Ip,
+    int? Port,
+    string MetadataJson,
+    string CheckUrl,
+    string AlarmUrl,
+    string HeartBeatMode,
+    RegisterWay RegisterWay,
+    bool RejectExisting,
+    bool AcceptMissingIdentifier = false);
+
+public sealed record ServiceInstanceRegistration(string UniqueId, ServiceInfo Instance, bool WasExisting);
+
+public sealed record HeartbeatReceipt(string ServiceInstanceId, DateTime ReceivedAt, string ServicesVersion);
+
+public interface IServiceInstanceManagementService
+{
+    Task<IReadOnlyList<ServiceInfo>> GetAllAsync(
+        ServiceStatus? status = null,
+        CancellationToken cancellationToken = default);
+
+    Task<ApplicationResult<ServiceInfo>> GetByIdAsync(
+        string uniqueId,
+        CancellationToken cancellationToken = default);
+
+    Task<ApplicationResult<ServiceInstanceRegistration>> RegisterAsync(
+        RegisterServiceInstanceCommand command,
+        CancellationToken cancellationToken = default);
+
+    Task<ApplicationResult> UnregisterAsync(
+        string uniqueId,
+        string fallbackServiceId = null,
+        bool succeedWhenRemovalFails = false,
+        CancellationToken cancellationToken = default);
+
+    Task<ApplicationResult<HeartbeatReceipt>> ReceiveHeartbeatAsync(
+        string uniqueId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/AgileConfig.Server.Application/ServiceInstances/ServiceInstanceManagementService.cs
+++ b/src/AgileConfig.Server.Application/ServiceInstances/ServiceInstanceManagementService.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AgileConfig.Server.Common.EventBus;
+using AgileConfig.Server.Data.Entity;
+using AgileConfig.Server.Event;
+using AgileConfig.Server.IService;
+
+namespace AgileConfig.Server.Application;
+
+public sealed class ServiceInstanceManagementService : IServiceInstanceManagementService
+{
+    private readonly IRegisterCenterService _registerCenterService;
+    private readonly IServiceInfoService _serviceInfoService;
+    private readonly ITinyEventBus _tinyEventBus;
+    private readonly TimeProvider _timeProvider;
+
+    public ServiceInstanceManagementService(
+        IRegisterCenterService registerCenterService,
+        IServiceInfoService serviceInfoService,
+        ITinyEventBus tinyEventBus,
+        TimeProvider timeProvider)
+    {
+        _registerCenterService = registerCenterService;
+        _serviceInfoService = serviceInfoService;
+        _tinyEventBus = tinyEventBus;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task<IReadOnlyList<ServiceInfo>> GetAllAsync(
+        ServiceStatus? status = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return status switch
+        {
+            ServiceStatus.Healthy => await _serviceInfoService.GetOnlineServiceInfoAsync(),
+            ServiceStatus.Unhealthy => await _serviceInfoService.GetOfflineServiceInfoAsync(),
+            _ => await _serviceInfoService.GetAllServiceInfoAsync()
+        };
+    }
+
+    public async Task<ApplicationResult<ServiceInfo>> GetByIdAsync(
+        string uniqueId,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var instance = string.IsNullOrWhiteSpace(uniqueId)
+            ? null
+            : await _serviceInfoService.GetByUniqueIdAsync(uniqueId);
+        return instance == null
+            ? ApplicationResult<ServiceInfo>.Failure(ApplicationError.NotFound)
+            : ApplicationResult<ServiceInfo>.Success(instance);
+    }
+
+    public async Task<ApplicationResult<ServiceInstanceRegistration>> RegisterAsync(
+        RegisterServiceInstanceCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        if (command == null) return ApplicationResult<ServiceInstanceRegistration>.Failure(ApplicationError.ValidationFailed);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var existing = await _serviceInfoService.GetByServiceIdAsync(command.ServiceId);
+        if (existing != null && command.RejectExisting)
+            return ApplicationResult<ServiceInstanceRegistration>.Failure(ApplicationError.Conflict);
+
+        var service = new ServiceInfo
+        {
+            ServiceId = command.ServiceId,
+            ServiceName = command.ServiceName,
+            Ip = command.Ip,
+            Port = command.Port,
+            MetaData = command.MetadataJson,
+            CheckUrl = command.CheckUrl,
+            AlarmUrl = command.AlarmUrl,
+            HeartBeatMode = command.HeartBeatMode,
+            RegisterWay = command.RegisterWay
+        };
+
+        var uniqueId = await _registerCenterService.RegisterAsync(service);
+        if (string.IsNullOrWhiteSpace(uniqueId))
+        {
+            if (!command.AcceptMissingIdentifier)
+                return ApplicationResult<ServiceInstanceRegistration>.Failure(ApplicationError.OperationFailed);
+
+            _tinyEventBus.Fire(new ServiceRegisteredEvent(uniqueId));
+            return ApplicationResult<ServiceInstanceRegistration>.Success(
+                new ServiceInstanceRegistration(uniqueId, service, existing != null));
+        }
+
+        _tinyEventBus.Fire(new ServiceRegisteredEvent(uniqueId));
+
+        var registered = await _serviceInfoService.GetByUniqueIdAsync(uniqueId) ?? service;
+        registered.Id ??= uniqueId;
+
+        return ApplicationResult<ServiceInstanceRegistration>.Success(
+            new ServiceInstanceRegistration(uniqueId, registered, existing != null));
+    }
+
+    public async Task<ApplicationResult> UnregisterAsync(
+        string uniqueId,
+        string fallbackServiceId = null,
+        bool succeedWhenRemovalFails = false,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var existing = string.IsNullOrWhiteSpace(uniqueId)
+            ? null
+            : await _serviceInfoService.GetByUniqueIdAsync(uniqueId);
+        if (existing == null) return ApplicationResult.Failure(ApplicationError.NotFound);
+
+        var removed = await _registerCenterService.UnRegisterAsync(uniqueId);
+        if (!removed && !string.IsNullOrWhiteSpace(fallbackServiceId))
+            removed = await _registerCenterService.UnRegisterByServiceIdAsync(fallbackServiceId);
+
+        if (!removed && !succeedWhenRemovalFails)
+            return ApplicationResult.Failure(ApplicationError.OperationFailed);
+
+        _tinyEventBus.Fire(new ServiceUnRegisterEvent(existing.Id));
+        return ApplicationResult.Success();
+    }
+
+    public async Task<ApplicationResult<HeartbeatReceipt>> ReceiveHeartbeatAsync(
+        string uniqueId,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (string.IsNullOrWhiteSpace(uniqueId) ||
+            !await _registerCenterService.ReceiveHeartbeatAsync(uniqueId))
+            return ApplicationResult<HeartbeatReceipt>.Failure(ApplicationError.NotFound);
+
+        var servicesVersion = await _serviceInfoService.ServicesMD5Cache();
+        return ApplicationResult<HeartbeatReceipt>.Success(new HeartbeatReceipt(
+            uniqueId,
+            _timeProvider.GetUtcNow().UtcDateTime,
+            servicesVersion));
+    }
+}

--- a/test/AgileConfig.Server.ApplicationTests/AgileConfig.Server.ApplicationTests.csproj
+++ b/test/AgileConfig.Server.ApplicationTests/AgileConfig.Server.ApplicationTests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AgileConfig.Server.Application\AgileConfig.Server.Application.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/AgileConfig.Server.ApplicationTests/ApplicationLayerDependencyTests.cs
+++ b/test/AgileConfig.Server.ApplicationTests/ApplicationLayerDependencyTests.cs
@@ -1,0 +1,21 @@
+using System.Linq;
+using AgileConfig.Server.Application;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AgileConfig.Server.ApplicationTests;
+
+[TestClass]
+public sealed class ApplicationLayerDependencyTests
+{
+    [TestMethod]
+    public void ApplicationAssembly_DoesNotReferenceHttpOrApisiteAssemblies()
+    {
+        var references = typeof(ApplicationResult).Assembly
+            .GetReferencedAssemblies()
+            .Select(x => x.Name)
+            .ToList();
+
+        Assert.IsFalse(references.Any(x => x.StartsWith("Microsoft.AspNetCore")));
+        Assert.DoesNotContain(references, "AgileConfig.Server.Apisite");
+    }
+}

--- a/test/AgileConfig.Server.ApplicationTests/ApplicationManagementServiceTests.cs
+++ b/test/AgileConfig.Server.ApplicationTests/ApplicationManagementServiceTests.cs
@@ -59,6 +59,8 @@ public sealed class ApplicationManagementServiceTests
         List<AppInheritanced> addedInheritance = null;
 
         appService.Setup(x => x.GetAsync("app-1")).ReturnsAsync((App)null);
+        appService.Setup(x => x.GetAsync("parent-a")).ReturnsAsync(new App { Id = "parent-a", Type = AppType.Inheritance });
+        appService.Setup(x => x.GetAsync("parent-b")).ReturnsAsync(new App { Id = "parent-b", Type = AppType.Inheritance });
         appService.Setup(x => x.AddAsync(It.IsAny<App>(), It.IsAny<List<AppInheritanced>>()))
             .Callback<App, List<AppInheritanced>>((app, inheritance) =>
             {
@@ -81,7 +83,8 @@ public sealed class ApplicationManagementServiceTests
             "secret",
             false,
             false,
-            new[] { "parent-a", "parent-b" }));
+            new[] { "parent-a", "parent-b" },
+            ValidateInheritanceReferences: true));
 
         Assert.IsTrue(result.Succeeded);
         Assert.AreSame(addedApp, result.Value);
@@ -193,6 +196,38 @@ public sealed class ApplicationManagementServiceTests
 
         var result = await service.UpdateAsync(new UpdateApplicationCommand(
             "app-1", "Changed", null, null, true, false, Array.Empty<string>()));
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ApplicationError.ValidationFailed, result.Error);
+        appService.Verify(x => x.UpdateAsync(It.IsAny<App>(), It.IsAny<List<AppInheritanced>>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_WithInvalidInheritanceReference_RejectsWithoutWriting()
+    {
+        var appService = new Mock<IAppService>();
+        var eventBus = new Mock<ITinyEventBus>();
+        appService.Setup(x => x.GetAsync("app-1")).ReturnsAsync((App)null);
+
+        var result = await CreateService(appService, eventBus).CreateAsync(new CreateApplicationCommand(
+            "app-1", "Application 1", null, null, true, false, new[] { "missing-parent" },
+            ValidateInheritanceReferences: true));
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ApplicationError.ValidationFailed, result.Error);
+        appService.Verify(x => x.AddAsync(It.IsAny<App>(), It.IsAny<List<AppInheritanced>>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task UpdateAsync_WithInheritanceIdentifierExceedingColumnLength_RejectsWithoutWriting()
+    {
+        var appService = new Mock<IAppService>();
+        var eventBus = new Mock<ITinyEventBus>();
+        appService.Setup(x => x.GetAsync("app-1")).ReturnsAsync(new App { Id = "app-1" });
+
+        var result = await CreateService(appService, eventBus).UpdateAsync(new UpdateApplicationCommand(
+            "app-1", "Application 1", null, null, true, false, new[] { new string('a', 37) },
+            ValidateInheritanceReferences: true));
 
         Assert.IsFalse(result.Succeeded);
         Assert.AreEqual(ApplicationError.ValidationFailed, result.Error);

--- a/test/AgileConfig.Server.ApplicationTests/ApplicationManagementServiceTests.cs
+++ b/test/AgileConfig.Server.ApplicationTests/ApplicationManagementServiceTests.cs
@@ -1,0 +1,277 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AgileConfig.Server.Application;
+using AgileConfig.Server.Common.EventBus;
+using AgileConfig.Server.Data.Entity;
+using AgileConfig.Server.Event;
+using AgileConfig.Server.IService;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace AgileConfig.Server.ApplicationTests;
+
+[TestClass]
+public sealed class ApplicationManagementServiceTests
+{
+    [TestMethod]
+    public async Task GetAllAsync_ReturnsApplicationsWithTheirInheritance()
+    {
+        var appService = new Mock<IAppService>();
+        var first = new App { Id = "app-1" };
+        var second = new App { Id = "app-2" };
+        appService.Setup(x => x.GetAllAppsAsync()).ReturnsAsync(new List<App> { first, second });
+        appService.Setup(x => x.GetInheritancedAppsAsync("app-1"))
+            .ReturnsAsync(new List<App> { new() { Id = "base-1" } });
+        appService.Setup(x => x.GetInheritancedAppsAsync("app-2"))
+            .ReturnsAsync(new List<App>());
+
+        var result = await CreateService(appService, new Mock<ITinyEventBus>()).GetAllAsync();
+
+        Assert.AreEqual(2, result.Count);
+        Assert.AreSame(first, result[0].Application);
+        CollectionAssert.AreEqual(new[] { "base-1" }, result[0].InheritedApplicationIds.ToArray());
+        Assert.AreSame(second, result[1].Application);
+        Assert.AreEqual(0, result[1].InheritedApplicationIds.Count);
+    }
+
+    [TestMethod]
+    public async Task GetAsync_WhenApplicationDoesNotExist_DoesNotLoadInheritance()
+    {
+        var appService = new Mock<IAppService>();
+        appService.Setup(x => x.GetAsync("missing")).ReturnsAsync((App)null);
+
+        var result = await CreateService(appService, new Mock<ITinyEventBus>()).GetAsync("missing");
+
+        Assert.IsNull(result);
+        appService.Verify(x => x.GetInheritancedAppsAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_MapsApplicationTimeCreatorAndInheritance()
+    {
+        var appService = new Mock<IAppService>();
+        var eventBus = new Mock<ITinyEventBus>();
+        var currentUser = BuildCurrentUser();
+        var timeProvider = new FixedTimeProvider(new DateTimeOffset(2025, 2, 3, 4, 5, 6, TimeSpan.Zero));
+        App addedApp = null;
+        List<AppInheritanced> addedInheritance = null;
+
+        appService.Setup(x => x.GetAsync("app-1")).ReturnsAsync((App)null);
+        appService.Setup(x => x.AddAsync(It.IsAny<App>(), It.IsAny<List<AppInheritanced>>()))
+            .Callback<App, List<AppInheritanced>>((app, inheritance) =>
+            {
+                addedApp = app;
+                addedInheritance = inheritance;
+            })
+            .ReturnsAsync(true);
+
+        var service = new ApplicationManagementService(
+            appService.Object,
+            eventBus.Object,
+            currentUser.Object,
+            timeProvider,
+            new Mock<IPreviewModeAccessor>().Object);
+
+        var result = await service.CreateAsync(new CreateApplicationCommand(
+            "app-1",
+            "Application 1",
+            "group-a",
+            "secret",
+            false,
+            false,
+            new[] { "parent-a", "parent-b" }));
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreSame(addedApp, result.Value);
+        Assert.AreEqual("app-1", addedApp.Id);
+        Assert.AreEqual("Application 1", addedApp.Name);
+        Assert.AreEqual("group-a", addedApp.Group);
+        Assert.AreEqual("secret", addedApp.Secret);
+        Assert.IsFalse(addedApp.Enabled);
+        Assert.AreEqual(AppType.PRIVATE, addedApp.Type);
+        Assert.AreEqual("user-1", addedApp.Creator);
+        Assert.AreEqual(timeProvider.GetLocalNow().DateTime, addedApp.CreateTime);
+        Assert.AreEqual(2, addedInheritance.Count);
+        Assert.AreEqual("parent-a", addedInheritance[0].InheritancedAppId);
+        Assert.AreEqual("parent-b", addedInheritance[1].InheritancedAppId);
+        Assert.AreEqual(0, addedInheritance[0].Sort);
+        Assert.AreEqual(1, addedInheritance[1].Sort);
+        Assert.IsTrue(addedInheritance.All(x => x.AppId == "app-1" && !string.IsNullOrWhiteSpace(x.Id)));
+        eventBus.Verify(x => x.Fire(It.IsAny<AddAppSuccessful>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_WhenIdentifierExists_ReturnsConflictWithoutWriting()
+    {
+        var appService = new Mock<IAppService>();
+        var eventBus = new Mock<ITinyEventBus>();
+        appService.Setup(x => x.GetAsync("app-1")).ReturnsAsync(new App { Id = "app-1" });
+
+        var service = CreateService(appService, eventBus);
+        var result = await service.CreateAsync(new CreateApplicationCommand(
+            "app-1", "Application 1", null, null, true, false, Array.Empty<string>()));
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ApplicationError.Conflict, result.Error);
+        appService.Verify(x => x.AddAsync(It.IsAny<App>(), It.IsAny<List<AppInheritanced>>()), Times.Never);
+        eventBus.Verify(x => x.Fire(It.IsAny<DeleteAppSuccessful>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task UpdateAsync_MapsExistingApplicationAndInheritance()
+    {
+        var appService = new Mock<IAppService>();
+        var eventBus = new Mock<ITinyEventBus>();
+        var currentUser = BuildCurrentUser();
+        var timeProvider = new FixedTimeProvider(new DateTimeOffset(2025, 3, 4, 5, 6, 7, TimeSpan.Zero));
+        var existing = new App
+        {
+            Id = "app-1",
+            Name = "Old name",
+            CreateTime = new DateTime(2020, 1, 1),
+            Creator = "original-user"
+        };
+        App updatedApp = null;
+        List<AppInheritanced> updatedInheritance = null;
+
+        appService.Setup(x => x.GetAsync("app-1")).ReturnsAsync(existing);
+        appService.Setup(x => x.UpdateAsync(It.IsAny<App>(), It.IsAny<List<AppInheritanced>>()))
+            .Callback<App, List<AppInheritanced>>((app, inheritance) =>
+            {
+                updatedApp = app;
+                updatedInheritance = inheritance;
+            })
+            .ReturnsAsync(true);
+
+        var service = new ApplicationManagementService(
+            appService.Object,
+            eventBus.Object,
+            currentUser.Object,
+            timeProvider,
+            new Mock<IPreviewModeAccessor>().Object);
+
+        var result = await service.UpdateAsync(new UpdateApplicationCommand(
+            "app-1",
+            "New name",
+            "group-b",
+            "new-secret",
+            true,
+            true,
+            new[] { "ignored-parent" }));
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreSame(existing, updatedApp);
+        Assert.AreEqual("New name", updatedApp.Name);
+        Assert.AreEqual("group-b", updatedApp.Group);
+        Assert.AreEqual("new-secret", updatedApp.Secret);
+        Assert.IsTrue(updatedApp.Enabled);
+        Assert.AreEqual(AppType.Inheritance, updatedApp.Type);
+        Assert.AreEqual(new DateTime(2020, 1, 1), updatedApp.CreateTime);
+        Assert.AreEqual(timeProvider.GetLocalNow().DateTime, updatedApp.UpdateTime);
+        Assert.AreEqual(0, updatedInheritance.Count);
+        eventBus.Verify(x => x.Fire(It.IsAny<EditAppSuccessful>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task UpdateAsync_InPreviewMode_RejectsDemoApplicationBeforeWriting()
+    {
+        var appService = new Mock<IAppService>();
+        var eventBus = new Mock<ITinyEventBus>();
+        var previewMode = new Mock<IPreviewModeAccessor>();
+        previewMode.SetupGet(x => x.IsPreviewMode).Returns(true);
+        appService.Setup(x => x.GetAsync("app-1"))
+            .ReturnsAsync(new App { Id = "app-1", Name = "test_app" });
+
+        var service = new ApplicationManagementService(
+            appService.Object,
+            eventBus.Object,
+            BuildCurrentUser().Object,
+            TimeProvider.System,
+            previewMode.Object);
+
+        var result = await service.UpdateAsync(new UpdateApplicationCommand(
+            "app-1", "Changed", null, null, true, false, Array.Empty<string>()));
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ApplicationError.ValidationFailed, result.Error);
+        appService.Verify(x => x.UpdateAsync(It.IsAny<App>(), It.IsAny<List<AppInheritanced>>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_PublishesDeleteEventAfterSuccessfulDelete()
+    {
+        var appService = new Mock<IAppService>();
+        var eventBus = new Mock<ITinyEventBus>();
+        var currentUser = BuildCurrentUser();
+        var app = new App { Id = "app-1", Name = "Application 1" };
+        appService.Setup(x => x.GetAsync("app-1")).ReturnsAsync(app);
+        appService.Setup(x => x.DeleteAsync(app)).ReturnsAsync(true);
+
+        var service = new ApplicationManagementService(
+            appService.Object,
+            eventBus.Object,
+            currentUser.Object,
+            TimeProvider.System,
+            new Mock<IPreviewModeAccessor>().Object);
+
+        var result = await service.DeleteAsync(new DeleteApplicationCommand("app-1"));
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreSame(app, result.Value);
+        eventBus.Verify(x => x.Fire(It.Is<DeleteAppSuccessful>(e =>
+            ReferenceEquals(e.App, app) && e.UserName == "alice")), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_WhenApplicationDoesNotExist_ReturnsNotFound()
+    {
+        var appService = new Mock<IAppService>();
+        var eventBus = new Mock<ITinyEventBus>();
+        appService.Setup(x => x.GetAsync("missing")).ReturnsAsync((App)null);
+
+        var service = CreateService(appService, eventBus);
+        var result = await service.DeleteAsync(new DeleteApplicationCommand("missing"));
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ApplicationError.NotFound, result.Error);
+        appService.Verify(x => x.DeleteAsync(It.IsAny<App>()), Times.Never);
+        eventBus.Verify(x => x.Fire(It.IsAny<DeleteAppSuccessful>()), Times.Never);
+    }
+
+    private static ApplicationManagementService CreateService(
+        Mock<IAppService> appService,
+        Mock<ITinyEventBus> eventBus)
+    {
+        return new ApplicationManagementService(
+            appService.Object,
+            eventBus.Object,
+            BuildCurrentUser().Object,
+            TimeProvider.System,
+            new Mock<IPreviewModeAccessor>().Object);
+    }
+
+    private static Mock<ICurrentUserAccessor> BuildCurrentUser()
+    {
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(x => x.UserName).Returns("alice");
+        currentUser.Setup(x => x.GetUserIdAsync()).ReturnsAsync("user-1");
+        return currentUser;
+    }
+
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _utcNow;
+
+        public FixedTimeProvider(DateTimeOffset utcNow)
+        {
+            _utcNow = utcNow;
+        }
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            return _utcNow;
+        }
+    }
+}

--- a/test/AgileConfig.Server.ApplicationTests/ConfigurationManagementServiceTests.cs
+++ b/test/AgileConfig.Server.ApplicationTests/ConfigurationManagementServiceTests.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AgileConfig.Server.Application;
+using AgileConfig.Server.Application.Configurations;
+using AgileConfig.Server.Common.EventBus;
+using AgileConfig.Server.Data.Entity;
+using AgileConfig.Server.Event;
+using AgileConfig.Server.IService;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace AgileConfig.Server.ApplicationTests;
+
+[TestClass]
+public sealed class ConfigurationManagementServiceTests
+{
+    private static readonly DateTimeOffset FixedNow = new(2026, 8, 24, 10, 30, 0, TimeSpan.FromHours(8));
+
+    [TestMethod]
+    public async Task CreateAsync_CreatesPendingConfigurationAndPublishesEvent()
+    {
+        var appService = new Mock<IAppService>();
+        appService.Setup(x => x.GetAsync("app-1")).ReturnsAsync(new App { Id = "app-1" });
+        var configService = new Mock<IConfigService>();
+        configService.Setup(x => x.GetByAppIdKeyEnv("app-1", "db", "connection", "TEST"))
+            .ReturnsAsync((Config)null);
+        Config saved = null;
+        configService.Setup(x => x.AddAsync(It.IsAny<Config>(), "TEST"))
+            .Callback<Config, string>((config, _) => saved = config)
+            .ReturnsAsync(true);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(x => x.UserName).Returns("operator");
+        var eventBus = new Mock<ITinyEventBus>();
+        var service = CreateService(appService, configService, currentUser, eventBus);
+
+        var result = await service.CreateAsync(new CreateConfigurationCommand(
+            "", "app-1", "db", "connection", "value", "description", "TEST"));
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreSame(saved, result.Value);
+        Assert.IsFalse(string.IsNullOrEmpty(saved.Id));
+        Assert.AreEqual(ConfigStatus.Enabled, saved.Status);
+        Assert.AreEqual(EditStatus.Add, saved.EditStatus);
+        Assert.AreEqual(OnlineStatus.WaitPublish, saved.OnlineStatus);
+        Assert.AreEqual(FixedNow.ToLocalTime().DateTime, saved.CreateTime);
+        eventBus.Verify(x => x.Fire(It.Is<AddConfigSuccessful>(e =>
+            e.Config == saved && e.UserName == "operator")), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_ReturnsConflictWithoutPersistingDuplicate()
+    {
+        var appService = new Mock<IAppService>();
+        appService.Setup(x => x.GetAsync("app-1")).ReturnsAsync(new App { Id = "app-1" });
+        var configService = new Mock<IConfigService>();
+        configService.Setup(x => x.GetByAppIdKeyEnv("app-1", "db", "connection", "TEST"))
+            .ReturnsAsync(new Config { Id = "existing" });
+        var service = CreateService(appService, configService);
+
+        var result = await service.CreateAsync(new CreateConfigurationCommand(
+            null, "app-1", "db", "connection", "value", null, "TEST"));
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ApplicationError.Conflict, result.Error);
+        configService.Verify(x => x.AddAsync(It.IsAny<Config>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task UpdateAsync_MarksPublishedConfigurationAsEdited()
+    {
+        var existing = new Config
+        {
+            Id = "config-1",
+            AppId = "app-1",
+            Group = "old",
+            Key = "key",
+            Value = "old-value",
+            Status = ConfigStatus.Enabled,
+            EditStatus = EditStatus.Commit,
+            OnlineStatus = OnlineStatus.Online,
+            Env = "TEST"
+        };
+        var appService = new Mock<IAppService>();
+        var configService = new Mock<IConfigService>();
+        configService.Setup(x => x.GetAsync("config-1", "TEST")).ReturnsAsync(existing);
+        configService.Setup(x => x.GetByAppIdAsync("app-1", "TEST"))
+            .ReturnsAsync(new List<Config> { existing });
+        configService.Setup(x => x.GetByAppIdKeyEnv("app-1", "new", "key", "TEST"))
+            .ReturnsAsync((Config)null);
+        configService.Setup(x => x.IsPublishedAsync("config-1", "TEST")).ReturnsAsync(true);
+        configService.Setup(x => x.UpdateAsync(existing, "TEST")).ReturnsAsync(true);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(x => x.UserName).Returns("operator");
+        var eventBus = new Mock<ITinyEventBus>();
+        var service = CreateService(appService, configService, currentUser, eventBus);
+
+        var result = await service.UpdateAsync(new UpdateConfigurationCommand(
+            "config-1", "app-1", "new", "key", "new-value", "description", "TEST"));
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreEqual(EditStatus.Edit, existing.EditStatus);
+        Assert.AreEqual(OnlineStatus.WaitPublish, existing.OnlineStatus);
+        Assert.AreEqual(FixedNow.DateTime, existing.UpdateTime);
+        eventBus.Verify(x => x.Fire(It.Is<EditConfigSuccessful>(e => e.Config == existing)), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task UpdateAsync_DescriptionOnlyChangeKeepsPublicationState()
+    {
+        var existing = new Config
+        {
+            Id = "config-1",
+            AppId = "app-1",
+            Group = "group",
+            Key = "key",
+            Value = "value",
+            Status = ConfigStatus.Enabled,
+            EditStatus = EditStatus.Commit,
+            OnlineStatus = OnlineStatus.Online,
+            Env = "TEST"
+        };
+        var appService = new Mock<IAppService>();
+        var configService = new Mock<IConfigService>();
+        configService.Setup(x => x.GetAsync("config-1", "TEST")).ReturnsAsync(existing);
+        configService.Setup(x => x.GetByAppIdAsync("app-1", "TEST"))
+            .ReturnsAsync(new List<Config> { existing });
+        configService.Setup(x => x.UpdateAsync(existing, "TEST")).ReturnsAsync(true);
+        var service = CreateService(appService, configService);
+
+        var result = await service.UpdateAsync(new UpdateConfigurationCommand(
+            "config-1", "app-1", "group", "key", "value", "new description", "TEST"));
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreEqual(EditStatus.Commit, existing.EditStatus);
+        Assert.AreEqual(OnlineStatus.Online, existing.OnlineStatus);
+        configService.Verify(x => x.IsPublishedAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task UpdateAsync_ReturnsConflictForChangedDuplicateKey()
+    {
+        var existing = new Config
+        {
+            Id = "config-1", AppId = "app-1", Group = "old", Key = "key", Value = "value"
+        };
+        var appService = new Mock<IAppService>();
+        var configService = new Mock<IConfigService>();
+        configService.Setup(x => x.GetAsync("config-1", "TEST")).ReturnsAsync(existing);
+        configService.Setup(x => x.GetByAppIdAsync("app-1", "TEST"))
+            .ReturnsAsync(new List<Config> { existing });
+        configService.Setup(x => x.GetByAppIdKeyEnv("app-1", "new", "key", "TEST"))
+            .ReturnsAsync(new Config { Id = "other" });
+        var service = CreateService(appService, configService);
+
+        var result = await service.UpdateAsync(new UpdateConfigurationCommand(
+            "config-1", "app-1", "new", "key", "value", null, "TEST"));
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ApplicationError.Conflict, result.Error);
+        configService.Verify(x => x.UpdateAsync(It.IsAny<Config>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_DeletesUnpublishedConfigurationImmediately()
+    {
+        var existing = new Config
+        {
+            Id = "config-1", AppId = "app-1", Status = ConfigStatus.Enabled,
+            EditStatus = EditStatus.Add, OnlineStatus = OnlineStatus.WaitPublish
+        };
+        var appService = new Mock<IAppService>();
+        var configService = new Mock<IConfigService>();
+        configService.Setup(x => x.GetAsync("config-1", "TEST")).ReturnsAsync(existing);
+        configService.Setup(x => x.IsPublishedAsync("config-1", "TEST")).ReturnsAsync(false);
+        configService.Setup(x => x.UpdateAsync(existing, "TEST")).ReturnsAsync(true);
+        var service = CreateService(appService, configService);
+
+        var result = await service.DeleteAsync(new DeleteConfigurationCommand("config-1", "TEST"));
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreEqual(ConfigStatus.Deleted, existing.Status);
+        Assert.AreEqual(EditStatus.Deleted, existing.EditStatus);
+        Assert.AreEqual(OnlineStatus.WaitPublish, existing.OnlineStatus);
+        configService.Verify(x => x.UpdateAsync(existing, "TEST"), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_KeepsPublishedConfigurationUntilRelease()
+    {
+        var existing = new Config
+        {
+            Id = "config-1", AppId = "app-1", Status = ConfigStatus.Enabled,
+            EditStatus = EditStatus.Commit, OnlineStatus = OnlineStatus.Online
+        };
+        var appService = new Mock<IAppService>();
+        var configService = new Mock<IConfigService>();
+        configService.Setup(x => x.GetAsync("config-1", "TEST")).ReturnsAsync(existing);
+        configService.Setup(x => x.IsPublishedAsync("config-1", "TEST")).ReturnsAsync(true);
+        configService.Setup(x => x.UpdateAsync(existing, "TEST")).ReturnsAsync(true);
+        var service = CreateService(appService, configService);
+
+        var result = await service.DeleteAsync(new DeleteConfigurationCommand("config-1", "TEST"));
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreEqual(ConfigStatus.Enabled, existing.Status);
+        Assert.AreEqual(EditStatus.Deleted, existing.EditStatus);
+        Assert.AreEqual(OnlineStatus.WaitPublish, existing.OnlineStatus);
+    }
+
+    [TestMethod]
+    public async Task GetAsync_HidesConfigurationFromAnotherApplicationOrDeletedState()
+    {
+        var configService = new Mock<IConfigService>();
+        configService.Setup(x => x.GetAsync("config-1", "TEST"))
+            .ReturnsAsync(new Config
+            {
+                Id = "config-1", AppId = "app-1", Status = ConfigStatus.Enabled,
+                EditStatus = EditStatus.Deleted
+            });
+        var service = CreateService(new Mock<IAppService>(), configService);
+
+        var result = await service.GetAsync("app-1", "TEST", "config-1");
+
+        Assert.IsNull(result);
+    }
+
+    private static ConfigurationManagementService CreateService(
+        Mock<IAppService> appService,
+        Mock<IConfigService> configService,
+        Mock<ICurrentUserAccessor> currentUser = null,
+        Mock<ITinyEventBus> eventBus = null)
+    {
+        return new ConfigurationManagementService(
+            appService.Object,
+            configService.Object,
+            (currentUser ?? new Mock<ICurrentUserAccessor>()).Object,
+            (eventBus ?? new Mock<ITinyEventBus>()).Object,
+            new FixedTimeProvider(FixedNow));
+    }
+
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _now;
+
+        public FixedTimeProvider(DateTimeOffset now)
+        {
+            _now = now;
+        }
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            return _now.ToUniversalTime();
+        }
+
+    }
+}

--- a/test/AgileConfig.Server.ApplicationTests/ConfigurationManagementServiceTests.cs
+++ b/test/AgileConfig.Server.ApplicationTests/ConfigurationManagementServiceTests.cs
@@ -102,7 +102,7 @@ public sealed class ConfigurationManagementServiceTests
         Assert.IsTrue(result.Succeeded);
         Assert.AreEqual(EditStatus.Edit, existing.EditStatus);
         Assert.AreEqual(OnlineStatus.WaitPublish, existing.OnlineStatus);
-        Assert.AreEqual(FixedNow.DateTime, existing.UpdateTime);
+        Assert.AreEqual(FixedNow.ToLocalTime().DateTime, existing.UpdateTime);
         eventBus.Verify(x => x.Fire(It.Is<EditConfigSuccessful>(e => e.Config == existing)), Times.Once);
     }
 

--- a/test/AgileConfig.Server.ApplicationTests/NodeManagementServiceTests.cs
+++ b/test/AgileConfig.Server.ApplicationTests/NodeManagementServiceTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AgileConfig.Server.Common.EventBus;
+using AgileConfig.Server.Data.Entity;
+using AgileConfig.Server.Event;
+using AgileConfig.Server.IService;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace AgileConfig.Server.Application.Tests;
+
+[TestClass]
+public sealed class NodeManagementServiceTests
+{
+    [TestMethod]
+    public async Task CreateAsync_NormalizesBuildsPersistsAndEchoesNode()
+    {
+        var repository = new Mock<IServerNodeService>();
+        var proxy = new Mock<IRemoteServerNodeProxy>();
+        var eventBus = new Mock<ITinyEventBus>();
+        var user = new Mock<ICurrentUserAccessor>();
+        var preview = new Mock<IPreviewModeAccessor>();
+        var timeProvider = new FixedTimeProvider(new DateTimeOffset(2026, 8, 24, 1, 2, 3, TimeSpan.Zero));
+        ServerNode persisted = null;
+
+        repository.Setup(x => x.GetAsync("https://node.example")).ReturnsAsync((ServerNode)null);
+        repository.Setup(x => x.AddAsync(It.IsAny<ServerNode>()))
+            .Callback<ServerNode>(x => persisted = x)
+            .ReturnsAsync(true);
+        proxy.Setup(x => x.TestEchoAsync("https://node.example")).Returns(Task.CompletedTask);
+        user.SetupGet(x => x.UserName).Returns("operator");
+
+        var service = new NodeManagementService(
+            repository.Object,
+            proxy.Object,
+            eventBus.Object,
+            user.Object,
+            preview.Object,
+            timeProvider);
+
+        var result = await service.CreateAsync(new CreateNodeCommand("https://node.example///", "primary"));
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreSame(persisted, result.Value);
+        Assert.AreEqual("https://node.example", persisted.Id);
+        Assert.AreEqual("primary", persisted.Remark);
+        Assert.AreEqual(NodeStatus.Offline, persisted.Status);
+        Assert.AreEqual(timeProvider.GetLocalNow().DateTime, persisted.CreateTime);
+        repository.Verify(x => x.AddAsync(It.IsAny<ServerNode>()), Times.Once);
+        proxy.Verify(x => x.TestEchoAsync("https://node.example"), Times.Once);
+        eventBus.Verify(x => x.Fire(It.Is<AddNodeSuccessful>(e =>
+            e.Node == persisted && e.UserName == "operator")), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_ReturnsConflictWithoutSideEffectsWhenAddressExists()
+    {
+        var repository = new Mock<IServerNodeService>();
+        var proxy = new Mock<IRemoteServerNodeProxy>();
+        var eventBus = new Mock<ITinyEventBus>();
+        var user = new Mock<ICurrentUserAccessor>();
+        var preview = new Mock<IPreviewModeAccessor>();
+        repository.Setup(x => x.GetAsync("https://node.example"))
+            .ReturnsAsync(new ServerNode { Id = "https://node.example" });
+
+        var service = new NodeManagementService(
+            repository.Object,
+            proxy.Object,
+            eventBus.Object,
+            user.Object,
+            preview.Object,
+            TimeProvider.System);
+
+        var result = await service.CreateAsync(new CreateNodeCommand("https://node.example/", null));
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ApplicationError.Conflict, result.Error);
+        repository.Verify(x => x.AddAsync(It.IsAny<ServerNode>()), Times.Never);
+        proxy.Verify(x => x.TestEchoAsync(It.IsAny<string>()), Times.Never);
+        eventBus.Verify(x => x.Fire(It.IsAny<AddNodeSuccessful>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_RespectsPreviewModeAndMissingNodes()
+    {
+        var repository = new Mock<IServerNodeService>();
+        var proxy = new Mock<IRemoteServerNodeProxy>();
+        var eventBus = new Mock<ITinyEventBus>();
+        var user = new Mock<ICurrentUserAccessor>();
+        var preview = new Mock<IPreviewModeAccessor>();
+        preview.SetupGet(x => x.IsPreviewMode).Returns(true);
+
+        var service = new NodeManagementService(
+            repository.Object,
+            proxy.Object,
+            eventBus.Object,
+            user.Object,
+            preview.Object,
+            TimeProvider.System);
+
+        var previewResult = await service.DeleteAsync("https://node.example");
+
+        Assert.IsFalse(previewResult.Succeeded);
+        Assert.AreEqual(ApplicationError.Forbidden, previewResult.Error);
+        repository.Verify(x => x.GetAsync(It.IsAny<string>()), Times.Never);
+
+        preview.SetupGet(x => x.IsPreviewMode).Returns(false);
+        repository.Setup(x => x.GetAsync("https://missing.example"))
+            .ReturnsAsync((ServerNode)null);
+
+        var missingResult = await service.DeleteAsync("https://missing.example/");
+
+        Assert.IsFalse(missingResult.Succeeded);
+        Assert.AreEqual(ApplicationError.NotFound, missingResult.Error);
+        repository.Verify(x => x.DeleteAsync(It.IsAny<ServerNode>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_DeletesAndPublishesDomainEvent()
+    {
+        var repository = new Mock<IServerNodeService>();
+        var proxy = new Mock<IRemoteServerNodeProxy>();
+        var eventBus = new Mock<ITinyEventBus>();
+        var user = new Mock<ICurrentUserAccessor>();
+        var preview = new Mock<IPreviewModeAccessor>();
+        var node = new ServerNode { Id = "https://node.example" };
+        user.SetupGet(x => x.UserName).Returns("operator");
+        repository.Setup(x => x.GetAsync(node.Id)).ReturnsAsync(node);
+        repository.Setup(x => x.DeleteAsync(node)).ReturnsAsync(true);
+
+        var service = new NodeManagementService(
+            repository.Object,
+            proxy.Object,
+            eventBus.Object,
+            user.Object,
+            preview.Object,
+            TimeProvider.System);
+
+        var result = await service.DeleteAsync("https://node.example/");
+
+        Assert.IsTrue(result.Succeeded);
+        repository.Verify(x => x.DeleteAsync(node), Times.Once);
+        eventBus.Verify(x => x.Fire(It.Is<DeleteNodeSuccessful>(e =>
+            e.Node == node && e.UserName == "operator")), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task GetAllAsync_ReturnsNodesInCreationOrder()
+    {
+        var repository = new Mock<IServerNodeService>();
+        repository.Setup(x => x.GetAllNodesAsync()).ReturnsAsync(new List<ServerNode>
+        {
+            new() { Id = "second", CreateTime = new DateTime(2026, 1, 2) },
+            new() { Id = "first", CreateTime = new DateTime(2026, 1, 1) }
+        });
+
+        var service = new NodeManagementService(
+            repository.Object,
+            Mock.Of<IRemoteServerNodeProxy>(),
+            Mock.Of<ITinyEventBus>(),
+            Mock.Of<ICurrentUserAccessor>(),
+            Mock.Of<IPreviewModeAccessor>(),
+            TimeProvider.System);
+
+        var nodes = await service.GetAllAsync();
+
+        Assert.AreEqual("first", nodes[0].Id);
+        Assert.AreEqual("second", nodes[1].Id);
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow()
+        {
+            return utcNow;
+        }
+    }
+}

--- a/test/AgileConfig.Server.ApplicationTests/PublishedConfigurationQueryServiceTests.cs
+++ b/test/AgileConfig.Server.ApplicationTests/PublishedConfigurationQueryServiceTests.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AgileConfig.Server.Application;
+using AgileConfig.Server.Application.Configurations;
+using AgileConfig.Server.Data.Entity;
+using AgileConfig.Server.IService;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace AgileConfig.Server.ApplicationTests;
+
+[TestClass]
+public sealed class PublishedConfigurationQueryServiceTests
+{
+    [TestMethod]
+    public async Task GetAsync_ReturnsTimelineAndInheritedPublishedConfigurations()
+    {
+        var appService = new Mock<IAppService>();
+        var configService = new Mock<IConfigService>();
+        var configurations = new List<Config> { new() { Id = "config-1" } };
+        appService.Setup(x => x.GetAsync("app-1"))
+            .ReturnsAsync(new App { Id = "app-1", Enabled = true });
+        configService.Setup(x => x.GetLastPublishTimelineVirtualIdAsyncWithCache("app-1", "PROD"))
+            .ReturnsAsync("timeline-1");
+        configService.Setup(x => x.GetPublishedConfigsByAppIdWithInheritance("app-1", "PROD"))
+            .ReturnsAsync(configurations);
+        var service = new PublishedConfigurationQueryService(appService.Object, configService.Object);
+
+        var result = await service.GetAsync("app-1", "PROD");
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreEqual("timeline-1", result.Value.PublishTimelineId);
+        Assert.AreSame(configurations, result.Value.Configurations);
+    }
+
+    [TestMethod]
+    public async Task GetAsync_WhenApplicationIsDisabled_ReturnsNotFoundWithoutLoadingConfigurations()
+    {
+        var appService = new Mock<IAppService>();
+        var configService = new Mock<IConfigService>();
+        appService.Setup(x => x.GetAsync("app-1"))
+            .ReturnsAsync(new App { Id = "app-1", Enabled = false });
+        var service = new PublishedConfigurationQueryService(appService.Object, configService.Object);
+
+        var result = await service.GetAsync("app-1", "PROD");
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ApplicationError.NotFound, result.Error);
+        configService.Verify(
+            x => x.GetPublishedConfigsByAppIdWithInheritance(It.IsAny<string>(), It.IsAny<string>()),
+            Times.Never);
+    }
+}

--- a/test/AgileConfig.Server.ApplicationTests/ReleaseManagementServiceTests.cs
+++ b/test/AgileConfig.Server.ApplicationTests/ReleaseManagementServiceTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AgileConfig.Server.Application;
+using AgileConfig.Server.Application.Releases;
+using AgileConfig.Server.Common.EventBus;
+using AgileConfig.Server.Data.Entity;
+using AgileConfig.Server.Event;
+using AgileConfig.Server.IService;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace AgileConfig.Server.ApplicationTests;
+
+[TestClass]
+public sealed class ReleaseManagementServiceTests
+{
+    [TestMethod]
+    public async Task PublishAsync_PublishesWithCurrentUserAndFiresEvent()
+    {
+        var appService = new Mock<IAppService>();
+        appService.Setup(x => x.GetAsync("app-1")).ReturnsAsync(new App { Id = "app-1" });
+        var configService = new Mock<IConfigService>();
+        configService.Setup(x => x.Publish(
+                "app-1", new[] { "config-1" }, "release log", "user-1", "TEST"))
+            .ReturnsAsync((true, "release-1"));
+        var timeline = new PublishTimeline
+        {
+            Id = "release-1", AppId = "app-1", Env = "TEST", Version = 4
+        };
+        configService.Setup(x => x.GetPublishTimeLineNodeAsync("release-1", "TEST"))
+            .ReturnsAsync(timeline);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(x => x.UserName).Returns("operator");
+        currentUser.Setup(x => x.GetUserIdAsync()).ReturnsAsync("user-1");
+        var eventBus = new Mock<ITinyEventBus>();
+        var service = CreateService(appService, configService, currentUser, eventBus);
+
+        var result = await service.PublishAsync(new PublishConfigurationsCommand(
+            "app-1", new[] { "config-1" }, "release log", "TEST"));
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreSame(timeline, result.Value);
+        configService.VerifyAll();
+        eventBus.Verify(x => x.Fire(It.Is<PublishConfigSuccessful>(e =>
+            e.PublishTimeline == timeline && e.UserName == "operator")), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task PublishAsync_ReturnsNotFoundWhenApplicationDoesNotExist()
+    {
+        var appService = new Mock<IAppService>();
+        appService.Setup(x => x.GetAsync("missing")).ReturnsAsync((App)null);
+        var configService = new Mock<IConfigService>();
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        var service = CreateService(appService, configService, currentUser);
+
+        var result = await service.PublishAsync(new PublishConfigurationsCommand(
+            "missing", null, null, "TEST"));
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ApplicationError.NotFound, result.Error);
+        configService.Verify(x => x.Publish(
+            It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+            Times.Never);
+        currentUser.Verify(x => x.GetUserIdAsync(), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task PublishAsync_WhenTimelineCannotBeLoaded_ReturnsFallbackAndStillFiresEvent()
+    {
+        var appService = new Mock<IAppService>();
+        appService.Setup(x => x.GetAsync("app-1")).ReturnsAsync(new App { Id = "app-1" });
+        var configService = new Mock<IConfigService>();
+        configService.Setup(x => x.Publish("app-1", null, "log", null, "TEST"))
+            .ReturnsAsync((true, "missing-release"));
+        configService.Setup(x => x.GetPublishTimeLineNodeAsync("missing-release", "TEST"))
+            .ReturnsAsync((PublishTimeline)null);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.Setup(x => x.GetUserIdAsync()).ReturnsAsync((string)null);
+        var eventBus = new Mock<ITinyEventBus>();
+        var service = CreateService(appService, configService, currentUser, eventBus);
+
+        var result = await service.PublishAsync(new PublishConfigurationsCommand(
+            "app-1", null, "log", "TEST"));
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreEqual("missing-release", result.Value.Id);
+        Assert.AreEqual("app-1", result.Value.AppId);
+        Assert.AreEqual("TEST", result.Value.Env);
+        eventBus.Verify(x => x.Fire(It.Is<PublishConfigSuccessful>(e =>
+            e.PublishTimeline == result.Value)), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task RollbackAsync_RollsBackAndFiresEvent()
+    {
+        var timeline = new PublishTimeline
+        {
+            Id = "release-1", AppId = "app-1", Env = "TEST", Version = 2
+        };
+        var appService = new Mock<IAppService>();
+        var configService = new Mock<IConfigService>();
+        configService.Setup(x => x.GetPublishTimeLineNodeAsync("release-1", "TEST"))
+            .ReturnsAsync(timeline);
+        configService.Setup(x => x.RollbackAsync("release-1", "TEST")).ReturnsAsync(true);
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(x => x.UserName).Returns("operator");
+        var eventBus = new Mock<ITinyEventBus>();
+        var service = CreateService(appService, configService, currentUser, eventBus);
+
+        var result = await service.RollbackAsync(new RollbackConfigurationCommand("release-1", "TEST"));
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreSame(timeline, result.Value);
+        configService.Verify(x => x.RollbackAsync("release-1", "TEST"), Times.Once);
+        eventBus.Verify(x => x.Fire(It.Is<RollbackConfigSuccessful>(e =>
+            e.TimelineNode == timeline && e.UserName == "operator")), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task RollbackAsync_ReturnsNotFoundWithoutCallingRollback()
+    {
+        var appService = new Mock<IAppService>();
+        var configService = new Mock<IConfigService>();
+        configService.Setup(x => x.GetPublishTimeLineNodeAsync("missing", "TEST"))
+            .ReturnsAsync((PublishTimeline)null);
+        var service = CreateService(appService, configService);
+
+        var result = await service.RollbackAsync(new RollbackConfigurationCommand("missing", "TEST"));
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ApplicationError.NotFound, result.Error);
+        configService.Verify(x => x.RollbackAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task GetAsync_OnlyReturnsReleaseOwnedByApplication()
+    {
+        var appService = new Mock<IAppService>();
+        var configService = new Mock<IConfigService>();
+        configService.Setup(x => x.GetPublishTimeLineNodeAsync("release-1", "TEST"))
+            .ReturnsAsync(new PublishTimeline { Id = "release-1", AppId = "other-app", Env = "TEST" });
+        var service = CreateService(appService, configService);
+
+        var result = await service.GetAsync("app-1", "TEST", "release-1");
+
+        Assert.IsNull(result);
+    }
+
+    private static ReleaseManagementService CreateService(
+        Mock<IAppService> appService,
+        Mock<IConfigService> configService,
+        Mock<ICurrentUserAccessor> currentUser = null,
+        Mock<ITinyEventBus> eventBus = null)
+    {
+        return new ReleaseManagementService(
+            appService.Object,
+            configService.Object,
+            (currentUser ?? new Mock<ICurrentUserAccessor>()).Object,
+            (eventBus ?? new Mock<ITinyEventBus>()).Object,
+            TimeProvider.System);
+    }
+}

--- a/test/AgileConfig.Server.ApplicationTests/ServiceInstanceManagementServiceTests.cs
+++ b/test/AgileConfig.Server.ApplicationTests/ServiceInstanceManagementServiceTests.cs
@@ -1,0 +1,282 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AgileConfig.Server.Common.EventBus;
+using AgileConfig.Server.Data.Entity;
+using AgileConfig.Server.Event;
+using AgileConfig.Server.IService;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace AgileConfig.Server.Application.Tests;
+
+[TestClass]
+public sealed class ServiceInstanceManagementServiceTests
+{
+    [TestMethod]
+    public async Task RegisterAsync_RejectsExistingServiceWhenRequested()
+    {
+        var serviceInfo = new Mock<IServiceInfoService>();
+        var existing = new ServiceInfo { Id = "existing", ServiceId = "orders" };
+        serviceInfo.Setup(x => x.GetByServiceIdAsync("orders")).ReturnsAsync(existing);
+
+        var registerCenter = new Mock<IRegisterCenterService>();
+        var eventBus = new Mock<ITinyEventBus>();
+        var service = new ServiceInstanceManagementService(
+            registerCenter.Object,
+            serviceInfo.Object,
+            eventBus.Object,
+            TimeProvider.System);
+
+        var result = await service.RegisterAsync(CreateCommand(rejectExisting: true));
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ApplicationError.Conflict, result.Error);
+        registerCenter.Verify(x => x.RegisterAsync(It.IsAny<ServiceInfo>()), Times.Never);
+        eventBus.Verify(x => x.Fire(It.IsAny<ServiceRegisteredEvent>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task RegisterAsync_BuildsEntityRegistersPublishesEventAndLoadsInstance()
+    {
+        var serviceInfo = new Mock<IServiceInfoService>();
+        serviceInfo.Setup(x => x.GetByServiceIdAsync("orders"))
+            .ReturnsAsync((ServiceInfo)null);
+        var registered = new ServiceInfo
+        {
+            Id = "instance-1",
+            ServiceId = "orders",
+            ServiceName = "Orders",
+            MetaData = "[\"zone-a\"]"
+        };
+        serviceInfo.Setup(x => x.GetByUniqueIdAsync("instance-1")).ReturnsAsync(registered);
+
+        var registerCenter = new Mock<IRegisterCenterService>();
+        ServiceInfo captured = null;
+        registerCenter.Setup(x => x.RegisterAsync(It.IsAny<ServiceInfo>()))
+            .Callback<ServiceInfo>(x => captured = x)
+            .ReturnsAsync("instance-1");
+        var eventBus = new Mock<ITinyEventBus>();
+
+        var service = new ServiceInstanceManagementService(
+            registerCenter.Object,
+            serviceInfo.Object,
+            eventBus.Object,
+            TimeProvider.System);
+
+        var result = await service.RegisterAsync(CreateCommand(rejectExisting: false));
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreEqual("instance-1", result.Value.UniqueId);
+        Assert.AreSame(registered, result.Value.Instance);
+        Assert.IsFalse(result.Value.WasExisting);
+        Assert.AreEqual("orders", captured.ServiceId);
+        Assert.AreEqual("Orders", captured.ServiceName);
+        Assert.AreEqual("10.0.0.5", captured.Ip);
+        Assert.AreEqual(8080, captured.Port);
+        Assert.AreEqual("[\"zone-a\"]", captured.MetaData);
+        Assert.AreEqual(RegisterWay.Auto, captured.RegisterWay);
+        eventBus.Verify(x => x.Fire(It.Is<ServiceRegisteredEvent>(e => e.UniqueId == "instance-1")), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task RegisterAsync_AllowsExistingServiceAndReportsUpdate()
+    {
+        var old = new ServiceInfo { Id = "instance-1", ServiceId = "orders" };
+        var serviceInfo = new Mock<IServiceInfoService>();
+        serviceInfo.Setup(x => x.GetByServiceIdAsync("orders")).ReturnsAsync(old);
+        serviceInfo.Setup(x => x.GetByUniqueIdAsync("instance-1")).ReturnsAsync(old);
+        var registerCenter = new Mock<IRegisterCenterService>();
+        registerCenter.Setup(x => x.RegisterAsync(It.IsAny<ServiceInfo>())).ReturnsAsync("instance-1");
+
+        var service = new ServiceInstanceManagementService(
+            registerCenter.Object,
+            serviceInfo.Object,
+            Mock.Of<ITinyEventBus>(),
+            TimeProvider.System);
+
+        var result = await service.RegisterAsync(CreateCommand(rejectExisting: false));
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.IsTrue(result.Value.WasExisting);
+    }
+
+    [TestMethod]
+    public async Task RegisterAsync_WhenReadbackLags_ReturnsTheRegisteredEntity()
+    {
+        var serviceInfo = new Mock<IServiceInfoService>();
+        serviceInfo.Setup(x => x.GetByServiceIdAsync("orders")).ReturnsAsync((ServiceInfo)null);
+        serviceInfo.Setup(x => x.GetByUniqueIdAsync("instance-1")).ReturnsAsync((ServiceInfo)null);
+        var registerCenter = new Mock<IRegisterCenterService>();
+        registerCenter.Setup(x => x.RegisterAsync(It.IsAny<ServiceInfo>())).ReturnsAsync("instance-1");
+        var eventBus = new Mock<ITinyEventBus>();
+        var service = new ServiceInstanceManagementService(
+            registerCenter.Object,
+            serviceInfo.Object,
+            eventBus.Object,
+            TimeProvider.System);
+
+        var result = await service.RegisterAsync(CreateCommand(rejectExisting: false));
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreEqual("instance-1", result.Value.Instance.Id);
+        Assert.AreEqual("orders", result.Value.Instance.ServiceId);
+        eventBus.Verify(x => x.Fire(It.Is<ServiceRegisteredEvent>(e => e.UniqueId == "instance-1")), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task RegisterAsync_AcceptsMissingIdentifierOnlyForLegacyCompatibility()
+    {
+        var serviceInfo = new Mock<IServiceInfoService>();
+        serviceInfo.Setup(x => x.GetByServiceIdAsync("orders")).ReturnsAsync((ServiceInfo)null);
+        var registerCenter = new Mock<IRegisterCenterService>();
+        registerCenter.Setup(x => x.RegisterAsync(It.IsAny<ServiceInfo>())).ReturnsAsync((string)null);
+        var eventBus = new Mock<ITinyEventBus>();
+        var service = new ServiceInstanceManagementService(
+            registerCenter.Object,
+            serviceInfo.Object,
+            eventBus.Object,
+            TimeProvider.System);
+        var command = CreateCommand(rejectExisting: false) with { AcceptMissingIdentifier = true };
+
+        var result = await service.RegisterAsync(command);
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.IsNull(result.Value.UniqueId);
+        eventBus.Verify(x => x.Fire(It.Is<ServiceRegisteredEvent>(e => e.UniqueId == null)), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task UnregisterAsync_UsesFallbackAndPublishesEvent()
+    {
+        var instance = new ServiceInfo { Id = "instance-1", ServiceId = "orders" };
+        var serviceInfo = new Mock<IServiceInfoService>();
+        serviceInfo.Setup(x => x.GetByUniqueIdAsync("instance-1")).ReturnsAsync(instance);
+        var registerCenter = new Mock<IRegisterCenterService>();
+        registerCenter.Setup(x => x.UnRegisterAsync("instance-1")).ReturnsAsync(false);
+        registerCenter.Setup(x => x.UnRegisterByServiceIdAsync("orders")).ReturnsAsync(true);
+        var eventBus = new Mock<ITinyEventBus>();
+
+        var service = new ServiceInstanceManagementService(
+            registerCenter.Object,
+            serviceInfo.Object,
+            eventBus.Object,
+            TimeProvider.System);
+
+        var result = await service.UnregisterAsync("instance-1", "orders");
+
+        Assert.IsTrue(result.Succeeded);
+        registerCenter.Verify(x => x.UnRegisterByServiceIdAsync("orders"), Times.Once);
+        eventBus.Verify(x => x.Fire(It.Is<ServiceUnRegisterEvent>(e => e.UniqueId == "instance-1")), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task UnregisterAsync_ReturnsNotFoundWithoutCallingRegisterCenter()
+    {
+        var serviceInfo = new Mock<IServiceInfoService>();
+        serviceInfo.Setup(x => x.GetByUniqueIdAsync("missing")).ReturnsAsync((ServiceInfo)null);
+        var registerCenter = new Mock<IRegisterCenterService>();
+
+        var service = new ServiceInstanceManagementService(
+            registerCenter.Object,
+            serviceInfo.Object,
+            Mock.Of<ITinyEventBus>(),
+            TimeProvider.System);
+
+        var result = await service.UnregisterAsync("missing");
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ApplicationError.NotFound, result.Error);
+        registerCenter.Verify(x => x.UnRegisterAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task UnregisterAsync_CanPreserveLegacySuccessAndNotificationOnRemovalFailure()
+    {
+        var instance = new ServiceInfo { Id = "instance-1", ServiceId = "orders" };
+        var serviceInfo = new Mock<IServiceInfoService>();
+        serviceInfo.Setup(x => x.GetByUniqueIdAsync("instance-1")).ReturnsAsync(instance);
+        var registerCenter = new Mock<IRegisterCenterService>();
+        registerCenter.Setup(x => x.UnRegisterAsync("instance-1")).ReturnsAsync(false);
+        var eventBus = new Mock<ITinyEventBus>();
+        var service = new ServiceInstanceManagementService(
+            registerCenter.Object,
+            serviceInfo.Object,
+            eventBus.Object,
+            TimeProvider.System);
+
+        var result = await service.UnregisterAsync("instance-1", succeedWhenRemovalFails: true);
+
+        Assert.IsTrue(result.Succeeded);
+        eventBus.Verify(x => x.Fire(It.Is<ServiceUnRegisterEvent>(e => e.UniqueId == "instance-1")), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task ReceiveHeartbeatAsync_ReturnsReceiptAndServiceVersion()
+    {
+        var serviceInfo = new Mock<IServiceInfoService>();
+        serviceInfo.Setup(x => x.ServicesMD5Cache()).ReturnsAsync("version-1");
+        var registerCenter = new Mock<IRegisterCenterService>();
+        registerCenter.Setup(x => x.ReceiveHeartbeatAsync("instance-1")).ReturnsAsync(true);
+        var instant = new DateTimeOffset(2026, 8, 24, 1, 2, 3, TimeSpan.Zero);
+
+        var service = new ServiceInstanceManagementService(
+            registerCenter.Object,
+            serviceInfo.Object,
+            Mock.Of<ITinyEventBus>(),
+            new FixedTimeProvider(instant));
+
+        var result = await service.ReceiveHeartbeatAsync("instance-1");
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreEqual("instance-1", result.Value.ServiceInstanceId);
+        Assert.AreEqual(instant.UtcDateTime, result.Value.ReceivedAt);
+        Assert.AreEqual("version-1", result.Value.ServicesVersion);
+    }
+
+    [TestMethod]
+    public async Task GetAllAsync_SelectsTheRequestedStatusQuery()
+    {
+        var serviceInfo = new Mock<IServiceInfoService>();
+        serviceInfo.Setup(x => x.GetOnlineServiceInfoAsync()).ReturnsAsync(new List<ServiceInfo>());
+        serviceInfo.Setup(x => x.GetOfflineServiceInfoAsync()).ReturnsAsync(new List<ServiceInfo>());
+        serviceInfo.Setup(x => x.GetAllServiceInfoAsync()).ReturnsAsync(new List<ServiceInfo>());
+
+        var service = new ServiceInstanceManagementService(
+            Mock.Of<IRegisterCenterService>(),
+            serviceInfo.Object,
+            Mock.Of<ITinyEventBus>(),
+            TimeProvider.System);
+
+        await service.GetAllAsync(ServiceStatus.Healthy);
+        await service.GetAllAsync(ServiceStatus.Unhealthy);
+        await service.GetAllAsync();
+
+        serviceInfo.Verify(x => x.GetOnlineServiceInfoAsync(), Times.Once);
+        serviceInfo.Verify(x => x.GetOfflineServiceInfoAsync(), Times.Once);
+        serviceInfo.Verify(x => x.GetAllServiceInfoAsync(), Times.Once);
+    }
+
+    private static RegisterServiceInstanceCommand CreateCommand(bool rejectExisting)
+    {
+        return new RegisterServiceInstanceCommand(
+            "orders",
+            "Orders",
+            "10.0.0.5",
+            8080,
+            "[\"zone-a\"]",
+            "https://orders/health",
+            "https://orders/alarm",
+            "client",
+            RegisterWay.Auto,
+            rejectExisting);
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow()
+        {
+            return utcNow;
+        }
+    }
+}

--- a/test/ApiSiteTests/ControllerDependencyArchitectureTests.cs
+++ b/test/ApiSiteTests/ControllerDependencyArchitectureTests.cs
@@ -1,0 +1,49 @@
+using System.Linq;
+using AgileConfig.Server.Apisite;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ApiSiteTests;
+
+[TestClass]
+public sealed class ControllerDependencyArchitectureTests
+{
+    [TestMethod]
+    public void Controllers_DoNotDependOnOtherControllers()
+    {
+        var controllerType = typeof(ControllerBase);
+        var invalidDependencies = typeof(Startup).Assembly
+            .GetTypes()
+            .Where(type => !type.IsAbstract && controllerType.IsAssignableFrom(type))
+            .SelectMany(type => type.GetConstructors()
+                .SelectMany(constructor => constructor.GetParameters()
+                    .Where(parameter => controllerType.IsAssignableFrom(parameter.ParameterType))
+                    .Select(parameter => $"{type.FullName} -> {parameter.ParameterType.FullName}")))
+            .ToList();
+
+        Assert.IsEmpty(invalidDependencies,
+            $"Controllers must call application services instead of other controllers: {string.Join(", ", invalidDependencies)}");
+    }
+
+    [TestMethod]
+    public void V2Controllers_UseApplicationServicesForUseCases()
+    {
+        var invalidDependencies = typeof(Startup).Assembly
+            .GetTypes()
+            .Where(type => !type.IsAbstract &&
+                           typeof(ControllerBase).IsAssignableFrom(type) &&
+                           type.Namespace == "AgileConfig.Server.Apisite.Controllers.api.v2")
+            .SelectMany(type => type.GetConstructors()
+                .SelectMany(constructor => constructor.GetParameters()
+                    .Where(parameter =>
+                        parameter.ParameterType.Namespace != "AgileConfig.Server.Application" &&
+                        parameter.ParameterType.Namespace != "AgileConfig.Server.Application.Configurations" &&
+                        parameter.ParameterType.Namespace != "AgileConfig.Server.Application.Releases" &&
+                        parameter.ParameterType.Namespace != "AgileConfig.Server.Apisite.Metrics")
+                    .Select(parameter => $"{type.FullName} -> {parameter.ParameterType.FullName}")))
+            .ToList();
+
+        Assert.IsEmpty(invalidDependencies,
+            $"V2 controllers must access use cases through the Application layer: {string.Join(", ", invalidDependencies)}");
+    }
+}

--- a/test/ApiSiteTests/SwaggerDocumentIntegrationTests.cs
+++ b/test/ApiSiteTests/SwaggerDocumentIntegrationTests.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using System.Net;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ApiSiteTests;
+
+[TestClass]
+public sealed class SwaggerDocumentIntegrationTests
+{
+    [TestMethod]
+    public async Task SwaggerDocuments_SeparateV1AndV2Routes()
+    {
+        using var host = new V2ApiSiteTestHost(previewMode: true);
+
+        using var v1Response = await host.Client.GetAsync("/swagger/v1/swagger.json");
+        using var v2Response = await host.Client.GetAsync("/swagger/v2/swagger.json");
+
+        Assert.AreEqual(HttpStatusCode.OK, v1Response.StatusCode);
+        Assert.AreEqual(HttpStatusCode.OK, v2Response.StatusCode);
+
+        using var v1 = JsonDocument.Parse(await v1Response.Content.ReadAsStringAsync());
+        using var v2 = JsonDocument.Parse(await v2Response.Content.ReadAsStringAsync());
+        var v1Paths = v1.RootElement.GetProperty("paths").EnumerateObject().Select(x => x.Name).ToList();
+        var v2Paths = v2.RootElement.GetProperty("paths").EnumerateObject().Select(x => x.Name).ToList();
+
+        Assert.IsNotEmpty(v1Paths);
+        Assert.IsNotEmpty(v2Paths);
+        Assert.IsFalse(v1Paths.Any(path => path.StartsWith("/api/v2/")));
+        Assert.IsTrue(v2Paths.All(path => path.StartsWith("/api/v2/")));
+        Assert.Contains("/api/v2/applications", v2Paths);
+    }
+}

--- a/test/ApiSiteTests/TestApiConfigController.cs
+++ b/test/ApiSiteTests/TestApiConfigController.cs
@@ -2,6 +2,7 @@ using AgileConfig.Server.Apisite.Controllers;
 using AgileConfig.Server.Apisite.Controllers.api.Models;
 using AgileConfig.Server.Apisite.Metrics;
 using AgileConfig.Server.Apisite.Models;
+using AgileConfig.Server.Application.Configurations;
 using AgileConfig.Server.Common.EventBus;
 using AgileConfig.Server.Data.Entity;
 using AgileConfig.Server.IService;
@@ -60,8 +61,7 @@ public class TestApiConfigController
             .ReturnsAsync(newConfigs);
 
         IMemoryCache memoryCache = null;
-        var userSErvice = new Mock<IUserService>();
-        var eventBus = new Mock<ITinyEventBus>();
+        var configurationManagementService = new Mock<IConfigurationManagementService>();
         var meterService = new Mock<IMeterService>();
 
         var httpContext = new DefaultHttpContext();
@@ -72,7 +72,7 @@ public class TestApiConfigController
             appService.Object,
             memoryCache,
             meterService.Object,
-            new ConfigController(configService.Object, appService.Object, userSErvice.Object, eventBus.Object)
+            configurationManagementService.Object
         );
         ctrl.ControllerContext = new ControllerContext
         {
@@ -102,8 +102,7 @@ public class TestApiConfigController
         appService.Setup(s => s.GetAsync(It.IsAny<string>())).ReturnsAsync(newApp1);
         var configService = new Mock<IConfigService>();
         IMemoryCache memoryCache = null;
-        var userSErvice = new Mock<IUserService>();
-        var eventBus = new Mock<ITinyEventBus>();
+        var configurationManagementService = new Mock<IConfigurationManagementService>();
         var meterService = new Mock<IMeterService>();
         var httpContext = new DefaultHttpContext();
         httpContext.Request.Headers["Authorization"] = "Basic MDAxOjE=";
@@ -113,7 +112,7 @@ public class TestApiConfigController
             appService.Object,
             memoryCache,
             meterService.Object,
-            new ConfigController(configService.Object, appService.Object, userSErvice.Object, eventBus.Object)
+            configurationManagementService.Object
         );
         ctrl.ControllerContext = new ControllerContext
         {

--- a/test/ApiSiteTests/TestAppController.cs
+++ b/test/ApiSiteTests/TestAppController.cs
@@ -7,7 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using AgileConfig.Server.Apisite.Controllers;
 using AgileConfig.Server.Apisite.Models;
-using AgileConfig.Server.Common.EventBus;
+using AgileConfig.Server.Application;
 using AgileConfig.Server.Data.Entity;
 using AgileConfig.Server.IService;
 using Microsoft.AspNetCore.Http;
@@ -24,9 +24,9 @@ public class TestAppController
     private static AppController BuildController(Mock<IAppService> appService, Mock<IConfigService> configService,
         Mock<ISettingService> settingService, Mock<IUserService> userService)
     {
-        var eventBus = new Mock<ITinyEventBus>();
+        var applicationManagementService = new Mock<IApplicationManagementService>();
         var ctl = new AppController(appService.Object, userService.Object, configService.Object, settingService.Object,
-            eventBus.Object);
+            applicationManagementService.Object);
         ctl.ControllerContext.HttpContext = new DefaultHttpContext();
         return ctl;
     }
@@ -44,21 +44,21 @@ public class TestAppController
         CultureInfo.CurrentUICulture = new CultureInfo("en-US", false);
 
         var appService = new Mock<IAppService>();
-        var logService = new Mock<ISysLogService>();
         var userService = new Mock<IUserService>();
-        var permissionService = new Mock<IPermissionService>();
         var configService = new Mock<IConfigService>();
         var settingService = new Mock<ISettingService>();
-        var eventBus = new Mock<ITinyEventBus>();
+        var applicationManagementService = new Mock<IApplicationManagementService>();
 
         var ctl = new AppController(appService.Object, userService.Object, configService.Object, settingService.Object,
-            eventBus.Object);
+            applicationManagementService.Object);
 
         ctl.ControllerContext.HttpContext = new DefaultHttpContext();
 
         Assert.ThrowsExactly<ArgumentNullException>(() => { ctl.Add(null).GetAwaiter().GetResult(); });
 
-        appService.Setup(s => s.GetAsync("01")).ReturnsAsync(new App());
+        applicationManagementService
+            .Setup(x => x.CreateAsync(It.Is<CreateApplicationCommand>(command => command.Id == "01")))
+            .ReturnsAsync(ApplicationResult<App>.Failure(ApplicationError.Conflict));
         var result = await ctl.Add(new AppVM
         {
             Id = "01"
@@ -69,10 +69,9 @@ public class TestAppController
         Assert.IsNotNull(jr.Value);
         Console.WriteLine(jr.Value.ToString());
         //Assert.IsTrue(jr.Value.ToString().Contains("Ӧ��Id�Ѵ��ڣ�����������"));
-        App nullApp = null;
-
-        appService.Setup(s => s.GetAsync("02")).ReturnsAsync(nullApp);
-        appService.Setup(s => s.AddAsync(It.IsAny<App>())).ReturnsAsync(false);
+        applicationManagementService
+            .Setup(x => x.CreateAsync(It.Is<CreateApplicationCommand>(command => command.Id == "02")))
+            .ReturnsAsync(ApplicationResult<App>.Failure(ApplicationError.OperationFailed));
         result = await ctl.Add(new AppVM
         {
             Id = "02"
@@ -84,8 +83,9 @@ public class TestAppController
         Console.WriteLine(jr.Value.ToString());
         Assert.IsTrue(jr.Value.ToString().Contains("success = False"));
 
-        appService.Setup(s => s.AddAsync(It.IsAny<App>())).ReturnsAsync(true);
-        appService.Setup(s => s.AddAsync(It.IsAny<App>(), It.IsAny<List<AppInheritanced>>())).ReturnsAsync(true);
+        applicationManagementService
+            .Setup(x => x.CreateAsync(It.Is<CreateApplicationCommand>(command => command.Id == "02")))
+            .ReturnsAsync(ApplicationResult<App>.Success(new App { Id = "02" }));
         Console.WriteLine(CultureInfo.CurrentUICulture);
         result = await ctl.Add(new AppVM
         {

--- a/test/ApiSiteTests/V2ApiSiteTestHost.cs
+++ b/test/ApiSiteTests/V2ApiSiteTestHost.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using AgileConfig.Server.Apisite;
+using AgileConfig.Server.Common;
+using AgileConfig.Server.Data.Abstraction;
+using AgileConfig.Server.Data.Freesql;
+using AgileConfig.Server.IService;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace ApiSiteTests;
+
+internal sealed class V2ApiSiteTestHost : IDisposable
+{
+    private readonly string _tempDirectory;
+    private readonly TestServer _server;
+
+    public V2ApiSiteTestHost()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), "AgileConfig.V2ApiSiteTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+
+        var dbPath = Path.Combine(_tempDirectory, "agile_config.db");
+        var testDbPath = Path.Combine(_tempDirectory, "agile_config_test.db");
+        var contentRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..",
+            "src", "AgileConfig.Server.Apisite"));
+
+        var settings = new Dictionary<string, string>
+        {
+            ["urls"] = "http://127.0.0.1:0",
+            ["adminConsole"] = "true",
+            ["saPassword"] = "1",
+            ["defaultApp"] = "",
+            ["cluster"] = "false",
+            ["preview_mode"] = "false",
+            ["alwaysTrustSsl"] = "false",
+            ["serviceHealthCheckInterval"] = "60",
+            ["serviceUnhealthInterval"] = "60",
+            ["removeServiceInterval"] = "0",
+            ["pathBase"] = "",
+            ["db:provider"] = "sqlite",
+            ["db:conn"] = $"Data Source={dbPath}",
+            ["db:env:TEST:provider"] = "sqlite",
+            ["db:env:TEST:conn"] = $"Data Source={testDbPath}",
+            ["otlp:instanceId"] = "",
+            ["otlp:logs:endpoint"] = "",
+            ["otlp:logs:headers"] = "",
+            ["otlp:logs:protocol"] = "http",
+            ["otlp:traces:endpoint"] = "",
+            ["otlp:traces:headers"] = "",
+            ["otlp:traces:protocol"] = "http",
+            ["otlp:metrics:endpoint"] = "",
+            ["otlp:metrics:headers"] = "",
+            ["otlp:metrics:protocol"] = "http",
+            ["SSO:enabled"] = "false",
+            ["SSO:loginButtonText"] = "",
+            ["JwtSetting:Issuer"] = "agileconfig.admin",
+            ["JwtSetting:Audience"] = "agileconfig.admin",
+            ["JwtSetting:ExpireSeconds"] = "86400"
+        };
+
+        Global.Config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+        Global.LoggerFactory = LoggerFactory.Create(builder => builder.SetMinimumLevel(LogLevel.Warning));
+
+        var builder = new WebHostBuilder()
+            .UseEnvironment("Development")
+            .UseContentRoot(contentRoot)
+            .UseConfiguration(Global.Config)
+            .ConfigureLogging(logging => logging.ClearProviders())
+            .UseStartup<Startup>();
+
+        _server = new TestServer(builder);
+        InitializeSystemData();
+
+        Client = _server.CreateClient();
+        Client.DefaultRequestHeaders.Authorization = BasicAuthentication("admin", "1");
+    }
+
+    public HttpClient Client { get; }
+
+    public async Task<HttpResponseMessage> SendAsync(
+        HttpMethod method,
+        string path,
+        object body = null,
+        AuthenticationHeaderValue authorization = null,
+        string etag = null)
+    {
+        using var request = new HttpRequestMessage(method, path);
+        if (authorization != null) request.Headers.Authorization = authorization;
+        if (etag != null) request.Headers.TryAddWithoutValidation("If-None-Match", etag);
+
+        if (body != null)
+        {
+            var json = JsonSerializer.Serialize(body);
+            request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+        }
+
+        return await Client.SendAsync(request);
+    }
+
+    public static AuthenticationHeaderValue BasicAuthentication(string username, string password)
+    {
+        return new AuthenticationHeaderValue("Basic",
+            Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}")));
+    }
+
+    public static async Task<JsonElement> ReadJsonAsync(HttpResponseMessage response)
+    {
+        var content = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(content);
+        return document.RootElement.Clone();
+    }
+
+    public void Dispose()
+    {
+        Client.Dispose();
+        _server.Dispose();
+
+        try
+        {
+            if (Directory.Exists(_tempDirectory)) Directory.Delete(_tempDirectory, true);
+        }
+        catch
+        {
+        }
+    }
+
+    private void InitializeSystemData()
+    {
+        var freeSqlFactory = _server.Services.GetRequiredService<IFreeSqlFactory>();
+        var initializationService = _server.Services.GetRequiredService<ISystemInitializationService>();
+
+        _ = freeSqlFactory.Create();
+        _ = freeSqlFactory.Create("TEST");
+
+        initializationService.TryInitDefaultEnvironment();
+        initializationService.TryInitJwtSecret();
+        initializationService.TryInitSystemRolesAndPermissions().GetAwaiter().GetResult();
+        initializationService.TryInitSaPassword();
+    }
+}

--- a/test/ApiSiteTests/V2ApiSiteTestHost.cs
+++ b/test/ApiSiteTests/V2ApiSiteTestHost.cs
@@ -24,7 +24,7 @@ internal sealed class V2ApiSiteTestHost : IDisposable
     private readonly string _tempDirectory;
     private readonly TestServer _server;
 
-    public V2ApiSiteTestHost()
+    public V2ApiSiteTestHost(bool previewMode = false)
     {
         _tempDirectory = Path.Combine(Path.GetTempPath(), "AgileConfig.V2ApiSiteTests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_tempDirectory);
@@ -41,7 +41,7 @@ internal sealed class V2ApiSiteTestHost : IDisposable
             ["saPassword"] = "1",
             ["defaultApp"] = "",
             ["cluster"] = "false",
-            ["preview_mode"] = "false",
+            ["preview_mode"] = previewMode.ToString(),
             ["alwaysTrustSsl"] = "false",
             ["serviceHealthCheckInterval"] = "60",
             ["serviceUnhealthInterval"] = "60",

--- a/test/ApiSiteTests/V2ControllerErrorMappingTests.cs
+++ b/test/ApiSiteTests/V2ControllerErrorMappingTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using AgileConfig.Server.Application;
+using AgileConfig.Server.Application.Configurations;
+using AgileConfig.Server.Apisite.Controllers.api.v2;
+using AgileConfig.Server.Apisite.Controllers.api.v2.Models;
+using AgileConfig.Server.Data.Entity;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace ApiSiteTests;
+
+[TestClass]
+public sealed class V2ControllerErrorMappingTests
+{
+    [TestMethod]
+    public async Task DeleteNode_WhenForbidden_Returns403()
+    {
+        var service = new Mock<INodeManagementService>();
+        service.Setup(x => x.DeleteAsync("http://node", default))
+            .ReturnsAsync(ApplicationResult.Failure(ApplicationError.Forbidden));
+        var controller = Initialize(new NodesController(service.Object));
+        var nodeId = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes("http://node"));
+
+        var result = await controller.Delete(nodeId);
+
+        Assert.AreEqual(StatusCodes.Status403Forbidden, ((ObjectResult)result).StatusCode);
+    }
+
+    [TestMethod]
+    public async Task UpdateApplication_WhenPersistenceFails_Returns500()
+    {
+        var service = new Mock<IApplicationManagementService>();
+        service.Setup(x => x.UpdateAsync(It.IsAny<UpdateApplicationCommand>()))
+            .ReturnsAsync(ApplicationResult<App>.Failure(ApplicationError.OperationFailed));
+        var controller = Initialize(new ApplicationsController(service.Object));
+
+        var result = await controller.Update("app-1", new UpdateApplicationRequest
+        {
+            Name = "Application",
+            Enabled = true
+        });
+
+        Assert.AreEqual(
+            StatusCodes.Status500InternalServerError,
+            ((ObjectResult)result.Result).StatusCode);
+    }
+
+    [TestMethod]
+    public async Task UpdateConfiguration_WhenPersistenceFails_Returns500()
+    {
+        var applications = new Mock<IApplicationManagementService>();
+        var configurations = new Mock<IConfigurationManagementService>();
+        configurations.Setup(x => x.GetAsync("app-1", "TEST", "config-1"))
+            .ReturnsAsync(new Config { Id = "config-1", AppId = "app-1", Env = "TEST" });
+        configurations.Setup(x => x.UpdateAsync(It.IsAny<UpdateConfigurationCommand>()))
+            .ReturnsAsync(ApplicationResult<Config>.Failure(ApplicationError.OperationFailed));
+        var controller = Initialize(new ConfigurationsController(applications.Object, configurations.Object));
+
+        var result = await controller.Update("app-1", "TEST", "config-1", new UpdateConfigurationRequest
+        {
+            Group = "default",
+            Key = "key",
+            Value = "value"
+        });
+
+        Assert.AreEqual(
+            StatusCodes.Status500InternalServerError,
+            ((ObjectResult)result.Result).StatusCode);
+    }
+
+    private static T Initialize<T>(T controller) where T : ControllerBase
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddControllers();
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                RequestServices = services.BuildServiceProvider()
+            }
+        };
+        return controller;
+    }
+}

--- a/test/ApiSiteTests/V2RestApiEndpointsIntegrationTests.cs
+++ b/test/ApiSiteTests/V2RestApiEndpointsIntegrationTests.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
+using AgileConfig.Server.Apisite.Controllers.api.v2.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ApiSiteTests;
@@ -175,6 +176,18 @@ public class V2RestApiEndpointsIntegrationTests
             etag: response.Headers.ETag.Tag);
         Assert.AreEqual(HttpStatusCode.NotModified, notModified.StatusCode);
 
+        var matchingList = await host.SendAsync(HttpMethod.Get,
+            $"/api/v2/applications/{applicationId}/environments/TEST/published-configurations",
+            authorization: applicationAuth,
+            etag: $"\"stale\", W/{response.Headers.ETag.Tag}");
+        Assert.AreEqual(HttpStatusCode.NotModified, matchingList.StatusCode);
+
+        var wildcard = await host.SendAsync(HttpMethod.Get,
+            $"/api/v2/applications/{applicationId}/environments/TEST/published-configurations",
+            authorization: applicationAuth,
+            etag: "*");
+        Assert.AreEqual(HttpStatusCode.NotModified, wildcard.StatusCode);
+
         var mismatch = await host.SendAsync(HttpMethod.Get,
             $"/api/v2/applications/another-app/environments/TEST/published-configurations",
             authorization: applicationAuth);
@@ -228,6 +241,19 @@ public class V2RestApiEndpointsIntegrationTests
             alarmUrl = ""
         };
 
+        var oversizedMetadata = await host.SendAsync(HttpMethod.Post, "/api/v2/service-instances", new
+        {
+            serviceId = $"oversized-{Guid.NewGuid():N}",
+            name = "V2 service",
+            ipAddress = "127.0.0.1",
+            port = 8080,
+            metadata = new[] { new string('x', RegisterServiceInstanceRequest.MetadataMaxLength - 3) },
+            heartbeatMode = "client",
+            healthCheckUrl = "",
+            alarmUrl = ""
+        });
+        await AssertProblem(oversizedMetadata, HttpStatusCode.BadRequest);
+
         var register = await host.SendAsync(HttpMethod.Post, "/api/v2/service-instances", request);
         Assert.AreEqual(HttpStatusCode.Created, register.StatusCode);
         var instance = await V2ApiSiteTestHost.ReadJsonAsync(register);
@@ -276,6 +302,14 @@ public class V2RestApiEndpointsIntegrationTests
             name = "Missing identifier"
         });
         await AssertProblem(invalidModel, HttpStatusCode.BadRequest);
+
+        var invalidInheritance = await host.SendAsync(HttpMethod.Post, "/api/v2/applications", new
+        {
+            id = $"child-{Guid.NewGuid():N}",
+            name = "Invalid inheritance application",
+            inheritsFrom = new[] { "missing-inheritance-source" }
+        });
+        await AssertProblem(invalidInheritance, HttpStatusCode.BadRequest);
 
         var missing = await host.SendAsync(HttpMethod.Get, "/api/v2/applications/does-not-exist");
         Assert.AreEqual(HttpStatusCode.NotFound, missing.StatusCode);

--- a/test/ApiSiteTests/V2RestApiEndpointsIntegrationTests.cs
+++ b/test/ApiSiteTests/V2RestApiEndpointsIntegrationTests.cs
@@ -1,0 +1,322 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ApiSiteTests;
+
+[TestClass]
+[DoNotParallelize]
+public class V2RestApiEndpointsIntegrationTests
+{
+    [TestMethod]
+    public async Task ApplicationsConfigurationsAndReleases_ShouldFollowRestSemantics()
+    {
+        using var host = new V2ApiSiteTestHost();
+        var applicationId = $"v2-{Guid.NewGuid():N}";
+
+        var createApplication = await host.SendAsync(HttpMethod.Post, "/api/v2/applications", new
+        {
+            id = applicationId,
+            name = "V2 integration application",
+            group = "integration",
+            secret = "client-secret",
+            enabled = true,
+            isInheritanceSource = false,
+            inheritsFrom = Array.Empty<string>()
+        });
+        Assert.AreEqual(HttpStatusCode.Created, createApplication.StatusCode);
+        Assert.AreEqual($"/api/v2/applications/{applicationId}", createApplication.Headers.Location?.PathAndQuery);
+        var application = await V2ApiSiteTestHost.ReadJsonAsync(createApplication);
+        Assert.AreEqual(applicationId, application.GetProperty("id").GetString());
+        Assert.IsFalse(application.TryGetProperty("secret", out _));
+
+        var duplicateApplication = await host.SendAsync(HttpMethod.Post, "/api/v2/applications", new
+        {
+            id = applicationId,
+            name = "Duplicate"
+        });
+        await AssertProblem(duplicateApplication, HttpStatusCode.Conflict);
+
+        var applicationList = await host.SendAsync(HttpMethod.Get, "/api/v2/applications");
+        Assert.AreEqual(HttpStatusCode.OK, applicationList.StatusCode);
+        var applications = await V2ApiSiteTestHost.ReadJsonAsync(applicationList);
+        Assert.IsTrue(applications.EnumerateArray().Any(x => x.GetProperty("id").GetString() == applicationId));
+
+        var updateApplication = await host.SendAsync(HttpMethod.Put, $"/api/v2/applications/{applicationId}", new
+        {
+            name = "V2 integration application updated",
+            group = "integration-updated",
+            secret = "client-secret",
+            enabled = true,
+            isInheritanceSource = false,
+            inheritsFrom = Array.Empty<string>()
+        });
+        Assert.AreEqual(HttpStatusCode.OK, updateApplication.StatusCode);
+        var updatedApplication = await V2ApiSiteTestHost.ReadJsonAsync(updateApplication);
+        Assert.AreEqual("integration-updated", updatedApplication.GetProperty("group").GetString());
+
+        var createConfiguration = await host.SendAsync(HttpMethod.Post,
+            $"/api/v2/applications/{applicationId}/environments/TEST/configurations", new
+            {
+                group = "database",
+                key = "connectionString",
+                value = "v1",
+                description = "first value"
+            });
+        Assert.AreEqual(HttpStatusCode.Created, createConfiguration.StatusCode);
+        var configuration = await V2ApiSiteTestHost.ReadJsonAsync(createConfiguration);
+        var configurationId = configuration.GetProperty("id").GetString();
+        Assert.IsFalse(string.IsNullOrWhiteSpace(configurationId));
+        StringAssert.Contains(createConfiguration.Headers.Location?.OriginalString, $"/configurations/{configurationId}");
+
+        var duplicateConfiguration = await host.SendAsync(HttpMethod.Post,
+            $"/api/v2/applications/{applicationId}/environments/TEST/configurations", new
+            {
+                group = "database",
+                key = "connectionString",
+                value = "duplicate"
+            });
+        await AssertProblem(duplicateConfiguration, HttpStatusCode.Conflict);
+
+        var firstRelease = await host.SendAsync(HttpMethod.Post,
+            $"/api/v2/applications/{applicationId}/environments/TEST/releases", new
+            {
+                log = "first release"
+            });
+        Assert.AreEqual(HttpStatusCode.Created, firstRelease.StatusCode);
+        var firstReleaseJson = await V2ApiSiteTestHost.ReadJsonAsync(firstRelease);
+        var firstReleaseId = firstReleaseJson.GetProperty("id").GetString();
+        Assert.AreEqual(1, firstReleaseJson.GetProperty("version").GetInt32());
+
+        var updateConfiguration = await host.SendAsync(HttpMethod.Put,
+            $"/api/v2/applications/{applicationId}/environments/TEST/configurations/{configurationId}", new
+            {
+                group = "database",
+                key = "connectionString",
+                value = "v2",
+                description = "second value"
+            });
+        Assert.AreEqual(HttpStatusCode.OK, updateConfiguration.StatusCode);
+        var updatedConfiguration = await V2ApiSiteTestHost.ReadJsonAsync(updateConfiguration);
+        Assert.AreEqual("v2", updatedConfiguration.GetProperty("value").GetString());
+        Assert.AreEqual("second value", updatedConfiguration.GetProperty("description").GetString());
+
+        var secondRelease = await host.SendAsync(HttpMethod.Post,
+            $"/api/v2/applications/{applicationId}/environments/TEST/releases", new
+            {
+                log = "second release",
+                configurationIds = new[] { configurationId }
+            });
+        Assert.AreEqual(HttpStatusCode.Created, secondRelease.StatusCode);
+
+        var releasesResponse = await host.SendAsync(HttpMethod.Get,
+            $"/api/v2/applications/{applicationId}/environments/TEST/releases");
+        Assert.AreEqual(HttpStatusCode.OK, releasesResponse.StatusCode);
+        var releases = await V2ApiSiteTestHost.ReadJsonAsync(releasesResponse);
+        Assert.IsTrue(releases.GetArrayLength() >= 2);
+
+        var releaseResponse = await host.SendAsync(HttpMethod.Get,
+            $"/api/v2/applications/{applicationId}/environments/TEST/releases/{firstReleaseId}");
+        Assert.AreEqual(HttpStatusCode.OK, releaseResponse.StatusCode);
+
+        var rollback = await host.SendAsync(HttpMethod.Post,
+            $"/api/v2/applications/{applicationId}/environments/TEST/releases/rollbacks", new
+            {
+                releaseId = firstReleaseId
+            });
+        Assert.AreEqual(HttpStatusCode.NoContent, rollback.StatusCode);
+
+        var deleteConfiguration = await host.SendAsync(HttpMethod.Delete,
+            $"/api/v2/applications/{applicationId}/environments/TEST/configurations/{configurationId}");
+        Assert.AreEqual(HttpStatusCode.NoContent, deleteConfiguration.StatusCode);
+
+        var missingConfiguration = await host.SendAsync(HttpMethod.Get,
+            $"/api/v2/applications/{applicationId}/environments/TEST/configurations/{configurationId}");
+        Assert.AreEqual(HttpStatusCode.NotFound, missingConfiguration.StatusCode);
+
+        var deleteApplication = await host.SendAsync(HttpMethod.Delete, $"/api/v2/applications/{applicationId}");
+        Assert.AreEqual(HttpStatusCode.NoContent, deleteApplication.StatusCode);
+
+        var missingApplication = await host.SendAsync(HttpMethod.Get, $"/api/v2/applications/{applicationId}");
+        Assert.AreEqual(HttpStatusCode.NotFound, missingApplication.StatusCode);
+
+        var legacyApi = await host.SendAsync(HttpMethod.Get, "/api/app");
+        Assert.AreEqual(HttpStatusCode.OK, legacyApi.StatusCode,
+            "The legacy REST API must remain available after adding v2 routes.");
+    }
+
+    [TestMethod]
+    public async Task PublishedConfigurations_ShouldUseApplicationAuthenticationAndEtags()
+    {
+        using var host = new V2ApiSiteTestHost();
+        var applicationId = $"p-{Guid.NewGuid():N}";
+        await CreateApplicationAndPublishedConfiguration(host, applicationId, "pull-secret");
+
+        var applicationAuth = V2ApiSiteTestHost.BasicAuthentication(applicationId, "pull-secret");
+        var response = await host.SendAsync(HttpMethod.Get,
+            $"/api/v2/applications/{applicationId}/environments/TEST/published-configurations",
+            authorization: applicationAuth);
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        Assert.IsTrue(response.Headers.ETag != null);
+        Assert.IsTrue(response.Headers.Contains("X-Publish-Timeline-Id"));
+        var configurations = await V2ApiSiteTestHost.ReadJsonAsync(response);
+        Assert.AreEqual(1, configurations.GetArrayLength());
+        Assert.AreEqual("published-value", configurations[0].GetProperty("value").GetString());
+        Assert.AreEqual(applicationId, configurations[0].GetProperty("applicationId").GetString());
+        Assert.AreEqual("TEST", configurations[0].GetProperty("environment").GetString());
+
+        var notModified = await host.SendAsync(HttpMethod.Get,
+            $"/api/v2/applications/{applicationId}/environments/TEST/published-configurations",
+            authorization: applicationAuth,
+            etag: response.Headers.ETag.Tag);
+        Assert.AreEqual(HttpStatusCode.NotModified, notModified.StatusCode);
+
+        var mismatch = await host.SendAsync(HttpMethod.Get,
+            $"/api/v2/applications/another-app/environments/TEST/published-configurations",
+            authorization: applicationAuth);
+        await AssertProblem(mismatch, HttpStatusCode.BadRequest);
+    }
+
+    [TestMethod]
+    public async Task Nodes_ShouldUseOpaqueIdentifiersAndStandardStatuses()
+    {
+        using var host = new V2ApiSiteTestHost();
+        var address = $"http://127.0.0.1:{Random.Shared.Next(20000, 30000)}";
+
+        var create = await host.SendAsync(HttpMethod.Post, "/api/v2/nodes", new
+        {
+            address,
+            remark = "v2 integration node"
+        });
+        Assert.AreEqual(HttpStatusCode.Created, create.StatusCode);
+        var node = await V2ApiSiteTestHost.ReadJsonAsync(create);
+        var nodeId = node.GetProperty("id").GetString();
+        Assert.IsFalse(string.IsNullOrWhiteSpace(nodeId));
+        Assert.IsFalse(nodeId.Contains('/'));
+
+        var get = await host.SendAsync(HttpMethod.Get, $"/api/v2/nodes/{nodeId}");
+        Assert.AreEqual(HttpStatusCode.OK, get.StatusCode);
+
+        var duplicate = await host.SendAsync(HttpMethod.Post, "/api/v2/nodes", new { address });
+        await AssertProblem(duplicate, HttpStatusCode.Conflict);
+
+        var delete = await host.SendAsync(HttpMethod.Delete, $"/api/v2/nodes/{nodeId}");
+        Assert.AreEqual(HttpStatusCode.NoContent, delete.StatusCode);
+
+        var missing = await host.SendAsync(HttpMethod.Get, $"/api/v2/nodes/{nodeId}");
+        Assert.AreEqual(HttpStatusCode.NotFound, missing.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task ServiceInstances_ShouldSupportRegistrationHeartbeatFilteringAndDeletion()
+    {
+        using var host = new V2ApiSiteTestHost();
+        var serviceId = $"service-{Guid.NewGuid():N}";
+        var request = new
+        {
+            serviceId,
+            name = "V2 service",
+            ipAddress = "127.0.0.1",
+            port = 8080,
+            metadata = new[] { "zone=local" },
+            heartbeatMode = "client",
+            healthCheckUrl = "http://127.0.0.1:8080/health",
+            alarmUrl = ""
+        };
+
+        var register = await host.SendAsync(HttpMethod.Post, "/api/v2/service-instances", request);
+        Assert.AreEqual(HttpStatusCode.Created, register.StatusCode);
+        var instance = await V2ApiSiteTestHost.ReadJsonAsync(register);
+        var instanceId = instance.GetProperty("id").GetString();
+        Assert.IsFalse(string.IsNullOrWhiteSpace(instanceId));
+
+        var get = await host.SendAsync(HttpMethod.Get, $"/api/v2/service-instances/{instanceId}");
+        Assert.AreEqual(HttpStatusCode.OK, get.StatusCode);
+
+        var healthy = await host.SendAsync(HttpMethod.Get, "/api/v2/service-instances?status=Healthy");
+        Assert.AreEqual(HttpStatusCode.OK, healthy.StatusCode);
+        var healthyInstances = await V2ApiSiteTestHost.ReadJsonAsync(healthy);
+        Assert.IsTrue(healthyInstances.EnumerateArray().Any(x => x.GetProperty("id").GetString() == instanceId));
+
+        var heartbeat = await host.SendAsync(HttpMethod.Put,
+            $"/api/v2/service-instances/{instanceId}/heartbeat");
+        Assert.AreEqual(HttpStatusCode.OK, heartbeat.StatusCode);
+        var heartbeatJson = await V2ApiSiteTestHost.ReadJsonAsync(heartbeat);
+        Assert.AreEqual(instanceId, heartbeatJson.GetProperty("serviceInstanceId").GetString());
+        Assert.IsFalse(string.IsNullOrWhiteSpace(heartbeatJson.GetProperty("servicesVersion").GetString()));
+
+        var updateRegistration = await host.SendAsync(HttpMethod.Post, "/api/v2/service-instances", request);
+        Assert.AreEqual(HttpStatusCode.OK, updateRegistration.StatusCode);
+        var updatedInstance = await V2ApiSiteTestHost.ReadJsonAsync(updateRegistration);
+        Assert.AreEqual(instanceId, updatedInstance.GetProperty("id").GetString());
+
+        var delete = await host.SendAsync(HttpMethod.Delete, $"/api/v2/service-instances/{instanceId}");
+        Assert.AreEqual(HttpStatusCode.NoContent, delete.StatusCode);
+
+        var missing = await host.SendAsync(HttpMethod.Put,
+            $"/api/v2/service-instances/{instanceId}/heartbeat");
+        Assert.AreEqual(HttpStatusCode.NotFound, missing.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task V2AdminEndpoints_ShouldRejectInvalidCredentialsAndInvalidModels()
+    {
+        using var host = new V2ApiSiteTestHost();
+
+        var invalidCredentials = await host.SendAsync(HttpMethod.Get, "/api/v2/applications",
+            authorization: V2ApiSiteTestHost.BasicAuthentication("admin", "wrong"));
+        Assert.AreEqual(HttpStatusCode.Forbidden, invalidCredentials.StatusCode);
+
+        var invalidModel = await host.SendAsync(HttpMethod.Post, "/api/v2/applications", new
+        {
+            name = "Missing identifier"
+        });
+        await AssertProblem(invalidModel, HttpStatusCode.BadRequest);
+
+        var missing = await host.SendAsync(HttpMethod.Get, "/api/v2/applications/does-not-exist");
+        Assert.AreEqual(HttpStatusCode.NotFound, missing.StatusCode);
+
+        var unknownEnvironment = await host.SendAsync(HttpMethod.Get,
+            "/api/v2/applications/does-not-exist/environments/UNKNOWN/configurations");
+        await AssertProblem(unknownEnvironment, HttpStatusCode.BadRequest);
+    }
+
+    private static async Task CreateApplicationAndPublishedConfiguration(
+        V2ApiSiteTestHost host,
+        string applicationId,
+        string secret)
+    {
+        var application = await host.SendAsync(HttpMethod.Post, "/api/v2/applications", new
+        {
+            id = applicationId,
+            name = "Published config application",
+            secret,
+            enabled = true
+        });
+        Assert.AreEqual(HttpStatusCode.Created, application.StatusCode);
+
+        var configuration = await host.SendAsync(HttpMethod.Post,
+            $"/api/v2/applications/{applicationId}/environments/TEST/configurations", new
+            {
+                key = "published-key",
+                value = "published-value"
+            });
+        Assert.AreEqual(HttpStatusCode.Created, configuration.StatusCode);
+
+        var release = await host.SendAsync(HttpMethod.Post,
+            $"/api/v2/applications/{applicationId}/environments/TEST/releases", new { log = "publish" });
+        Assert.AreEqual(HttpStatusCode.Created, release.StatusCode);
+    }
+
+    private static async Task AssertProblem(HttpResponseMessage response, HttpStatusCode expectedStatus)
+    {
+        Assert.AreEqual(expectedStatus, response.StatusCode);
+        StringAssert.Contains(response.Content.Headers.ContentType?.MediaType, "problem");
+        var problem = await V2ApiSiteTestHost.ReadJsonAsync(response);
+        Assert.AreEqual((int)expectedStatus, problem.GetProperty("status").GetInt32());
+    }
+}


### PR DESCRIPTION
## Summary

- add a resource-oriented v2 REST API for applications, configurations, releases, nodes, published configurations, and service instances
- introduce `AgileConfig.Server.Application` so legacy and v2 controllers share transport-independent use cases without controller-to-controller dependencies
- preserve legacy API routes and response contracts while mapping v2 failures to REST-appropriate status codes and ProblemDetails
- split Swagger into independent v1 and v2 documents
- add application-layer unit tests, API integration tests, error-mapping tests, and architecture dependency tests

## Verification

- `dotnet build AgileConfig.sln --no-restore`
- Application tests: 40 passed
- API/integration/architecture tests: 22 passed
- SQLite service regression tests: 40 passed
- `git diff --check`

Docker-backed MongoDB, MySQL, and PostgreSQL tests were not run locally.