### PR TITLE
refactor: migrate user and role management to application layer

### DIFF
--- a/src/AgileConfig.Server.Apisite/Controllers/RoleController.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/RoleController.cs
@@ -1,13 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using AgileConfig.Server.Application;
+using AgileConfig.Server.Application.Roles;
 using AgileConfig.Server.Apisite.Filters;
 using AgileConfig.Server.Apisite.Models;
-using AgileConfig.Server.Common;
 using AgileConfig.Server.Common.Resources;
-using AgileConfig.Server.Data.Abstraction;
-using AgileConfig.Server.Data.Entity;
+using AgileConfig.Server.Common;
 using AgileConfig.Server.IService;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -17,32 +16,22 @@ namespace AgileConfig.Server.Apisite.Controllers;
 [Authorize]
 public class RoleController : Controller
 {
-    private readonly IRoleFunctionRepository _roleFunctionRepository;
-    private readonly IRoleService _roleService;
+    private readonly IRoleManagementService _roleManagementService;
 
-    public RoleController(IRoleService roleService, IRoleFunctionRepository roleFunctionRepository)
+    public RoleController(IRoleManagementService roleManagementService)
     {
-        _roleService = roleService;
-        _roleFunctionRepository = roleFunctionRepository;
+        _roleManagementService = roleManagementService;
     }
 
     [HttpGet]
     public async Task<IActionResult> List()
     {
-        var roles = await _roleService.GetAllAsync();
-        // Filter out Super Administrator role to prevent it from being assigned through the frontend
-        var vms = new List<RoleVM>();
-        foreach (var role in roles.Where(r => r.Id != SystemRoleConstants.SuperAdminId))
-            vms.Add(await ToViewModel(role));
-
-        vms = vms.OrderByDescending(r => r.IsSystem)
-            .ThenBy(r => r.Name)
-            .ToList();
+        var roles = await _roleManagementService.GetAllAsync();
 
         return Json(new
         {
             success = true,
-            data = vms
+            data = roles.Select(ToViewModel).ToList()
         });
     }
 
@@ -52,7 +41,7 @@ public class RoleController : Controller
         return Json(new
         {
             success = true,
-            data = Functions.GetAllPermissions()
+            data = _roleManagementService.GetSupportedPermissions()
         });
     }
 
@@ -62,17 +51,13 @@ public class RoleController : Controller
     {
         if (model == null) throw new ArgumentNullException(nameof(model));
 
-        var role = new Role
-        {
-            Id = model.Id,
-            Name = model.Name,
-            Description = model.Description ?? string.Empty,
-            IsSystem = false
-        };
+        var result = await _roleManagementService.CreateAsync(new CreateRoleCommand(
+            model.Id,
+            model.Name,
+            model.Description,
+            model.Functions));
 
-        await _roleService.CreateAsync(role, model.Functions ?? Enumerable.Empty<string>());
-
-        return Json(new { success = true });
+        return Json(new { success = result.Succeeded });
     }
 
     [TypeFilter(typeof(PermissionCheckAttribute), Arguments = new object[] { Functions.Role_Edit })]
@@ -81,28 +66,22 @@ public class RoleController : Controller
     {
         if (model == null) throw new ArgumentNullException(nameof(model));
 
-        // Prevent editing SuperAdministrator role
-        if (model.Id == SystemRoleConstants.SuperAdminId)
+        var result = await _roleManagementService.UpdateAsync(new UpdateRoleCommand(
+            model.Id,
+            model.Name,
+            model.Description,
+            model.Functions));
+        if (result.Error == ApplicationError.Forbidden)
             return Json(new
             {
                 success = false,
                 message = "SuperAdministrator role cannot be edited"
             });
 
-        var role = new Role
-        {
-            Id = model.Id,
-            Name = model.Name,
-            Description = model.Description ?? string.Empty,
-            IsSystem = model.IsSystem
-        };
-
-        var result = await _roleService.UpdateAsync(role, model.Functions ?? Enumerable.Empty<string>());
-
         return Json(new
         {
-            success = result,
-            message = result ? string.Empty : Messages.UpdateRoleFailed
+            success = result.Succeeded,
+            message = result.Succeeded ? string.Empty : Messages.UpdateRoleFailed
         });
     }
 
@@ -112,32 +91,30 @@ public class RoleController : Controller
     {
         if (string.IsNullOrWhiteSpace(id)) throw new ArgumentNullException(nameof(id));
 
-        // Prevent deleting SuperAdministrator role
-        if (id == SystemRoleConstants.SuperAdminId)
+        var result = await _roleManagementService.DeleteAsync(id);
+        if (result.Error == ApplicationError.Forbidden && id == SystemRoleConstants.SuperAdminId)
             return Json(new
             {
                 success = false,
                 message = "SuperAdministrator role cannot be deleted"
             });
 
-        var result = await _roleService.DeleteAsync(id);
         return Json(new
         {
-            success = result,
-            message = result ? string.Empty : Messages.DeleteRoleFailed
+            success = result.Succeeded,
+            message = result.Succeeded ? string.Empty : Messages.DeleteRoleFailed
         });
     }
 
-    private async Task<RoleVM> ToViewModel(Role role)
+    private static RoleVM ToViewModel(RoleDetails details)
     {
-        var roleFunctions = await _roleFunctionRepository.QueryAsync(x => x.RoleId == role.Id);
         return new RoleVM
         {
-            Id = role.Id,
-            Name = role.Name,
-            Description = role.Description,
-            IsSystem = role.IsSystem,
-            Functions = roleFunctions.Select(rf => rf.FunctionId).ToList()
+            Id = details.Role.Id,
+            Name = details.Role.Name,
+            Description = details.Role.Description,
+            IsSystem = details.Role.IsSystem,
+            Functions = details.Functions.ToList()
         };
     }
 }

--- a/src/AgileConfig.Server.Apisite/Controllers/UserController.cs
+++ b/src/AgileConfig.Server.Apisite/Controllers/UserController.cs
@@ -1,15 +1,11 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using AgileConfig.Server.Application;
+using AgileConfig.Server.Application.Users;
 using AgileConfig.Server.Apisite.Filters;
 using AgileConfig.Server.Apisite.Models;
-using AgileConfig.Server.Apisite.Utilites;
-using AgileConfig.Server.Common;
-using AgileConfig.Server.Common.EventBus;
 using AgileConfig.Server.Common.Resources;
-using AgileConfig.Server.Data.Entity;
-using AgileConfig.Server.Event;
 using AgileConfig.Server.IService;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -19,16 +15,11 @@ namespace AgileConfig.Server.Apisite.Controllers;
 [Authorize]
 public class UserController : Controller
 {
-    private const string DefaultPassword = "123456";
-    private readonly ITinyEventBus _tinyEventBus;
-    private readonly IUserService _userService;
+    private readonly IUserManagementService _userManagementService;
 
-    public UserController(IUserService userService,
-        ITinyEventBus tinyEventBus
-    )
+    public UserController(IUserManagementService userManagementService)
     {
-        _userService = userService;
-        _tinyEventBus = tinyEventBus;
+        _userManagementService = userManagementService;
     }
 
     [HttpGet]
@@ -38,38 +29,16 @@ public class UserController : Controller
         if (current <= 0) throw new ArgumentException(Messages.CurrentCannotBeLessThanOneUser);
         if (pageSize <= 0) throw new ArgumentException(Messages.PageSizeCannotBeLessThanOneUser);
 
-        var users = await _userService.GetAll();
-        users = users.Where(x => x.Status == UserStatus.Normal && x.Id != SystemSettings.SuperAdminId).ToList();
-        if (!string.IsNullOrEmpty(userName))
-            users = users.Where(x => x.UserName != null && x.UserName.Contains(userName)).ToList();
-        if (!string.IsNullOrEmpty(team)) users = users.Where(x => x.Team != null && x.Team.Contains(team)).ToList();
-        users = users.OrderByDescending(x => x.CreateTime).ToList();
-
-        var pageList = users.Skip((current - 1) * pageSize).Take(pageSize);
-        var total = users.Count;
-
-        var vms = new List<UserVM>();
-        foreach (var item in pageList)
-        {
-            var roles = await _userService.GetUserRolesAsync(item.Id);
-            var vm = new UserVM
-            {
-                Id = item.Id,
-                UserName = item.UserName,
-                Team = item.Team,
-                UserRoleIds = roles.Select(r => r.Id).ToList(),
-                UserRoleNames = roles.Select(r => r.Name).ToList()
-            };
-            vms.Add(vm);
-        }
+        var result = await _userManagementService.SearchAsync(
+            new SearchUsersQuery(userName, team, current, pageSize));
 
         return Json(new
         {
-            current,
-            pageSize,
+            current = result.Current,
+            pageSize = result.PageSize,
             success = true,
-            total,
-            data = vms
+            total = result.Total,
+            data = result.Users.Select(ToViewModel).ToList()
         });
     }
 
@@ -79,37 +48,22 @@ public class UserController : Controller
     {
         if (model == null) throw new ArgumentNullException(nameof(model));
 
-        var oldUsers = await _userService.GetUsersByNameAsync(model.UserName);
-        if (oldUsers.Any(x => x.Status == UserStatus.Normal))
+        var result = await _userManagementService.CreateAsync(new CreateUserCommand(
+            model.UserName,
+            model.Password,
+            model.Team,
+            model.UserRoleIds));
+        if (result.Error == ApplicationError.Conflict)
             return Json(new
             {
                 success = false,
                 message = Messages.UserAlreadyExists(model.UserName)
             });
 
-        var user = new User();
-        user.Id = Guid.NewGuid().ToString("N");
-        var salt = Guid.NewGuid().ToString("N");
-        user.Salt = salt;
-        user.Password = Encrypt.Md5(model.Password + salt);
-        user.Status = UserStatus.Normal;
-        user.Team = model.Team;
-        user.CreateTime = DateTime.Now;
-        user.UserName = model.UserName;
-
-        var addUserResult = await _userService.AddAsync(user);
-        var roleIds = model.UserRoleIds?.Where(x => !string.IsNullOrWhiteSpace(x)).Distinct().ToList() ??
-                      new List<string>();
-        if (!roleIds.Any()) roleIds.Add(SystemRoleConstants.OperatorId);
-
-        var addUserRoleResult = await _userService.UpdateUserRolesAsync(user.Id, roleIds);
-
-        if (addUserResult) _tinyEventBus.Fire(new AddUserSuccessful(user, this.GetCurrentUserName()));
-
         return Json(new
         {
-            success = addUserResult && addUserRoleResult,
-            message = !(addUserResult && addUserRoleResult) ? Messages.AddUserFailed : ""
+            success = result.Succeeded,
+            message = !result.Succeeded ? Messages.AddUserFailed : ""
         });
     }
 
@@ -119,30 +73,21 @@ public class UserController : Controller
     {
         if (model == null) throw new ArgumentNullException(nameof(model));
 
-        var user = await _userService.GetUserAsync(model.Id);
-        if (user == null)
+        var result = await _userManagementService.UpdateAsync(new UpdateUserCommand(
+            model.Id,
+            model.Team,
+            model.UserRoleIds));
+        if (result.Error == ApplicationError.NotFound)
             return Json(new
             {
                 success = false,
                 message = Messages.UserNotFoundForOperation
             });
 
-        user.Team = model.Team;
-        user.UpdateTime = DateTime.Now;
-
-        var result = await _userService.UpdateAsync(user);
-        var roleIds = model.UserRoleIds?.Where(x => !string.IsNullOrWhiteSpace(x)).Distinct().ToList() ??
-                      new List<string>();
-        if (!roleIds.Any()) roleIds.Add(SystemRoleConstants.OperatorId);
-
-        var reuslt1 = await _userService.UpdateUserRolesAsync(user.Id, roleIds);
-
-        if (result) _tinyEventBus.Fire(new EditUserSuccessful(user, this.GetCurrentUserName()));
-
         return Json(new
         {
-            success = result && reuslt1,
-            message = !(result && reuslt1) ? Messages.UpdateUserFailed : ""
+            success = result.Succeeded,
+            message = !result.Succeeded ? Messages.UpdateUserFailed : ""
         });
     }
 
@@ -153,23 +98,18 @@ public class UserController : Controller
     {
         if (string.IsNullOrEmpty(userId)) throw new ArgumentNullException("userId");
 
-        var user = await _userService.GetUserAsync(userId);
-        if (user == null)
+        var result = await _userManagementService.ResetPasswordAsync(userId);
+        if (result.Error == ApplicationError.NotFound)
             return Json(new
             {
                 success = false,
                 message = Messages.UserNotFoundForOperation
             });
 
-        user.Password = Encrypt.Md5(DefaultPassword + user.Salt);
-
-        var result = await _userService.UpdateAsync(user);
-        if (result) _tinyEventBus.Fire(new ResetUserPasswordSuccessful(this.GetCurrentUserName(), user.UserName));
-
         return Json(new
         {
-            success = result,
-            message = !result ? Messages.ResetUserPasswordFailed : ""
+            success = result.Succeeded,
+            message = !result.Succeeded ? Messages.ResetUserPasswordFailed : ""
         });
     }
 
@@ -179,34 +119,29 @@ public class UserController : Controller
     {
         if (string.IsNullOrEmpty(userId)) throw new ArgumentNullException(nameof(userId));
 
-        var user = await _userService.GetUserAsync(userId);
-        if (user == null)
+        var result = await _userManagementService.DeleteAsync(userId);
+        if (result.Error == ApplicationError.NotFound)
             return Json(new
             {
                 success = false,
                 message = Messages.UserNotFoundForOperation
             });
 
-        user.Status = UserStatus.Deleted;
-        var result = await _userService.UpdateAsync(user);
-        if (result) _tinyEventBus.Fire(new DeleteUserSuccessful(user, this.GetCurrentUserName()));
-
         return Json(new
         {
-            success = result,
-            message = !result ? Messages.DeleteUserFailed : ""
+            success = result.Succeeded,
+            message = !result.Succeeded ? Messages.DeleteUserFailed : ""
         });
     }
 
     [HttpGet]
     public async Task<IActionResult> AdminUsers()
     {
-        var adminUsers = await _userService.GetUsersByRoleAsync(SystemRoleConstants.AdminId);
-        adminUsers = adminUsers.Where(x => x.Status == UserStatus.Normal).ToList();
+        var adminUsers = await _userManagementService.GetAdministratorsAsync();
         return Json(new
         {
             success = true,
-            data = adminUsers.OrderBy(x => x.Team).ThenBy(x => x.UserName).Select(x => new UserVM
+            data = adminUsers.Select(x => new UserVM
             {
                 Id = x.Id,
                 UserName = x.UserName,
@@ -218,18 +153,29 @@ public class UserController : Controller
     [HttpGet]
     public async Task<IActionResult> AllUsers()
     {
-        var users = await _userService.GetAll();
-        users = users.Where(x => x.Status == UserStatus.Normal && x.Id != SystemSettings.SuperAdminId).ToList();
+        var users = await _userManagementService.GetAllActiveAsync();
 
         return Json(new
         {
             success = true,
-            data = users.OrderBy(x => x.Team).ThenBy(x => x.UserName).Select(x => new UserVM
+            data = users.Select(x => new UserVM
             {
                 Id = x.Id,
                 UserName = x.UserName,
                 Team = x.Team
             })
         });
+    }
+
+    private static UserVM ToViewModel(UserDetails details)
+    {
+        return new UserVM
+        {
+            Id = details.User.Id,
+            UserName = details.User.UserName,
+            Team = details.User.Team,
+            UserRoleIds = details.RoleIds.ToList(),
+            UserRoleNames = details.RoleNames.ToList()
+        };
     }
 }

--- a/src/AgileConfig.Server.Application/Roles/RoleManagementContracts.cs
+++ b/src/AgileConfig.Server.Application/Roles/RoleManagementContracts.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AgileConfig.Server.Data.Entity;
+
+namespace AgileConfig.Server.Application.Roles;
+
+public sealed record CreateRoleCommand(
+    string Id,
+    string Name,
+    string Description,
+    IReadOnlyList<string> Functions);
+
+public sealed record UpdateRoleCommand(
+    string Id,
+    string Name,
+    string Description,
+    IReadOnlyList<string> Functions);
+
+public sealed record RoleDetails(Role Role, IReadOnlyList<string> Functions);
+
+public interface IRoleManagementService
+{
+    Task<IReadOnlyList<RoleDetails>> GetAllAsync();
+
+    IReadOnlyList<string> GetSupportedPermissions();
+
+    Task<ApplicationResult<Role>> CreateAsync(CreateRoleCommand command);
+
+    Task<ApplicationResult<Role>> UpdateAsync(UpdateRoleCommand command);
+
+    Task<ApplicationResult> DeleteAsync(string id);
+}

--- a/src/AgileConfig.Server.Application/Roles/RoleManagementService.cs
+++ b/src/AgileConfig.Server.Application/Roles/RoleManagementService.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AgileConfig.Server.Common;
+using AgileConfig.Server.Data.Entity;
+using AgileConfig.Server.IService;
+
+namespace AgileConfig.Server.Application.Roles;
+
+public sealed class RoleManagementService : IRoleManagementService
+{
+    private readonly IRoleService _roleService;
+
+    public RoleManagementService(IRoleService roleService)
+    {
+        _roleService = roleService;
+    }
+
+    public async Task<IReadOnlyList<RoleDetails>> GetAllAsync()
+    {
+        var roles = (await _roleService.GetAllAsync())
+            .Where(x => x.Id != SystemRoleConstants.SuperAdminId)
+            .OrderByDescending(x => x.IsSystem)
+            .ThenBy(x => x.Name)
+            .ToList();
+        var details = new List<RoleDetails>(roles.Count);
+        foreach (var role in roles)
+            details.Add(new RoleDetails(role, await _roleService.GetFunctionsAsync(role.Id)));
+
+        return details;
+    }
+
+    public IReadOnlyList<string> GetSupportedPermissions()
+    {
+        return Functions.GetAllPermissions();
+    }
+
+    public async Task<ApplicationResult<Role>> CreateAsync(CreateRoleCommand command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        if (!string.IsNullOrWhiteSpace(command.Id) && await _roleService.GetAsync(command.Id) != null)
+            return ApplicationResult<Role>.Failure(ApplicationError.Conflict);
+
+        var role = new Role
+        {
+            Id = command.Id,
+            Name = command.Name,
+            Description = command.Description ?? string.Empty,
+            IsSystem = false
+        };
+        var created = await _roleService.CreateAsync(role, NormalizeFunctions(command.Functions));
+        return ApplicationResult<Role>.Success(created);
+    }
+
+    public async Task<ApplicationResult<Role>> UpdateAsync(UpdateRoleCommand command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        var existing = await _roleService.GetAsync(command.Id);
+        if (existing == null) return ApplicationResult<Role>.Failure(ApplicationError.NotFound);
+        if (existing.Id == SystemRoleConstants.SuperAdminId)
+            return ApplicationResult<Role>.Failure(ApplicationError.Forbidden);
+
+        var role = new Role
+        {
+            Id = existing.Id,
+            Name = command.Name,
+            Description = command.Description ?? string.Empty,
+            IsSystem = existing.IsSystem
+        };
+        var succeeded = await _roleService.UpdateAsync(role, NormalizeFunctions(command.Functions));
+        return succeeded
+            ? ApplicationResult<Role>.Success(role)
+            : ApplicationResult<Role>.Failure(ApplicationError.OperationFailed);
+    }
+
+    public async Task<ApplicationResult> DeleteAsync(string id)
+    {
+        var existing = await _roleService.GetAsync(id);
+        if (existing == null) return ApplicationResult.Failure(ApplicationError.NotFound);
+        if (existing.IsSystem) return ApplicationResult.Failure(ApplicationError.Forbidden);
+
+        return await _roleService.DeleteAsync(id)
+            ? ApplicationResult.Success()
+            : ApplicationResult.Failure(ApplicationError.OperationFailed);
+    }
+
+    private static IReadOnlyList<string> NormalizeFunctions(IReadOnlyList<string> functions)
+    {
+        return functions?
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Distinct()
+            .ToList() ?? [];
+    }
+}

--- a/src/AgileConfig.Server.Application/ServiceCollectionExt.cs
+++ b/src/AgileConfig.Server.Application/ServiceCollectionExt.cs
@@ -1,6 +1,8 @@
 using System;
 using AgileConfig.Server.Application.Configurations;
 using AgileConfig.Server.Application.Releases;
+using AgileConfig.Server.Application.Roles;
+using AgileConfig.Server.Application.Users;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace AgileConfig.Server.Application;
@@ -16,6 +18,8 @@ public static class ServiceCollectionExt
         services.AddScoped<IReleaseManagementService, ReleaseManagementService>();
         services.AddScoped<INodeManagementService, NodeManagementService>();
         services.AddScoped<IServiceInstanceManagementService, ServiceInstanceManagementService>();
+        services.AddScoped<IUserManagementService, UserManagementService>();
+        services.AddScoped<IRoleManagementService, RoleManagementService>();
         return services;
     }
 }

--- a/src/AgileConfig.Server.Application/Users/UserManagementContracts.cs
+++ b/src/AgileConfig.Server.Application/Users/UserManagementContracts.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AgileConfig.Server.Data.Entity;
+
+namespace AgileConfig.Server.Application.Users;
+
+public sealed record SearchUsersQuery(
+    string UserName,
+    string Team,
+    int Current,
+    int PageSize);
+
+public sealed record CreateUserCommand(
+    string UserName,
+    string Password,
+    string Team,
+    IReadOnlyList<string> RoleIds);
+
+public sealed record UpdateUserCommand(
+    string Id,
+    string Team,
+    IReadOnlyList<string> RoleIds);
+
+public sealed record UserDetails(
+    User User,
+    IReadOnlyList<string> RoleIds,
+    IReadOnlyList<string> RoleNames);
+
+public sealed record UserSearchResult(
+    int Current,
+    int PageSize,
+    int Total,
+    IReadOnlyList<UserDetails> Users);
+
+public interface IUserManagementService
+{
+    Task<UserSearchResult> SearchAsync(SearchUsersQuery query);
+
+    Task<ApplicationResult<User>> CreateAsync(CreateUserCommand command);
+
+    Task<ApplicationResult<User>> UpdateAsync(UpdateUserCommand command);
+
+    Task<ApplicationResult<User>> ResetPasswordAsync(string userId);
+
+    Task<ApplicationResult<User>> DeleteAsync(string userId);
+
+    Task<IReadOnlyList<User>> GetAdministratorsAsync();
+
+    Task<IReadOnlyList<User>> GetAllActiveAsync();
+}

--- a/src/AgileConfig.Server.Application/Users/UserManagementService.cs
+++ b/src/AgileConfig.Server.Application/Users/UserManagementService.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AgileConfig.Server.Common;
+using AgileConfig.Server.Common.EventBus;
+using AgileConfig.Server.Data.Entity;
+using AgileConfig.Server.Event;
+using AgileConfig.Server.IService;
+
+namespace AgileConfig.Server.Application.Users;
+
+public sealed class UserManagementService : IUserManagementService
+{
+    private const string DefaultPassword = "123456";
+    private readonly ICurrentUserAccessor _currentUserAccessor;
+    private readonly ITinyEventBus _eventBus;
+    private readonly TimeProvider _timeProvider;
+    private readonly IUserService _userService;
+
+    public UserManagementService(
+        IUserService userService,
+        ITinyEventBus eventBus,
+        ICurrentUserAccessor currentUserAccessor,
+        TimeProvider timeProvider)
+    {
+        _userService = userService;
+        _eventBus = eventBus;
+        _currentUserAccessor = currentUserAccessor;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task<UserSearchResult> SearchAsync(SearchUsersQuery query)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        if (query.Current <= 0 || query.PageSize <= 0) throw new ArgumentOutOfRangeException(nameof(query));
+
+        var users = (await _userService.GetAll())
+            .Where(IsVisibleUser)
+            .Where(x => string.IsNullOrEmpty(query.UserName) ||
+                        x.UserName != null && x.UserName.Contains(query.UserName))
+            .Where(x => string.IsNullOrEmpty(query.Team) ||
+                        x.Team != null && x.Team.Contains(query.Team))
+            .OrderByDescending(x => x.CreateTime)
+            .ToList();
+
+        var page = users
+            .Skip((query.Current - 1) * query.PageSize)
+            .Take(query.PageSize)
+            .ToList();
+        var details = new List<UserDetails>(page.Count);
+        foreach (var user in page)
+        {
+            var roles = await _userService.GetUserRolesAsync(user.Id);
+            details.Add(new UserDetails(
+                user,
+                roles.Select(x => x.Id).ToList(),
+                roles.Select(x => x.Name).ToList()));
+        }
+
+        return new UserSearchResult(query.Current, query.PageSize, users.Count, details);
+    }
+
+    public async Task<ApplicationResult<User>> CreateAsync(CreateUserCommand command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var existingUsers = await _userService.GetUsersByNameAsync(command.UserName);
+        if (existingUsers.Any(x => x.Status == UserStatus.Normal))
+            return ApplicationResult<User>.Failure(ApplicationError.Conflict);
+
+        var salt = Guid.NewGuid().ToString("N");
+        var user = new User
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Salt = salt,
+            Password = Encrypt.Md5(command.Password + salt),
+            Status = UserStatus.Normal,
+            Team = command.Team,
+            CreateTime = GetLocalNow(),
+            UserName = command.UserName
+        };
+
+        var userCreated = await _userService.AddAsync(user);
+        var rolesUpdated = await _userService.UpdateUserRolesAsync(user.Id, NormalizeRoleIds(command.RoleIds));
+        if (userCreated) _eventBus.Fire(new AddUserSuccessful(user, _currentUserAccessor.UserName));
+
+        return userCreated && rolesUpdated
+            ? ApplicationResult<User>.Success(user)
+            : ApplicationResult<User>.Failure(ApplicationError.OperationFailed, user);
+    }
+
+    public async Task<ApplicationResult<User>> UpdateAsync(UpdateUserCommand command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var user = await _userService.GetUserAsync(command.Id);
+        if (user == null) return ApplicationResult<User>.Failure(ApplicationError.NotFound);
+
+        user.Team = command.Team;
+        user.UpdateTime = GetLocalNow();
+
+        var userUpdated = await _userService.UpdateAsync(user);
+        var rolesUpdated = await _userService.UpdateUserRolesAsync(user.Id, NormalizeRoleIds(command.RoleIds));
+        if (userUpdated) _eventBus.Fire(new EditUserSuccessful(user, _currentUserAccessor.UserName));
+
+        return userUpdated && rolesUpdated
+            ? ApplicationResult<User>.Success(user)
+            : ApplicationResult<User>.Failure(ApplicationError.OperationFailed, user);
+    }
+
+    public async Task<ApplicationResult<User>> ResetPasswordAsync(string userId)
+    {
+        var user = await _userService.GetUserAsync(userId);
+        if (user == null) return ApplicationResult<User>.Failure(ApplicationError.NotFound);
+
+        user.Password = Encrypt.Md5(DefaultPassword + user.Salt);
+        var succeeded = await _userService.UpdateAsync(user);
+        if (!succeeded) return ApplicationResult<User>.Failure(ApplicationError.OperationFailed, user);
+
+        _eventBus.Fire(new ResetUserPasswordSuccessful(_currentUserAccessor.UserName, user.UserName));
+        return ApplicationResult<User>.Success(user);
+    }
+
+    public async Task<ApplicationResult<User>> DeleteAsync(string userId)
+    {
+        var user = await _userService.GetUserAsync(userId);
+        if (user == null) return ApplicationResult<User>.Failure(ApplicationError.NotFound);
+
+        user.Status = UserStatus.Deleted;
+        var succeeded = await _userService.UpdateAsync(user);
+        if (!succeeded) return ApplicationResult<User>.Failure(ApplicationError.OperationFailed, user);
+
+        _eventBus.Fire(new DeleteUserSuccessful(user, _currentUserAccessor.UserName));
+        return ApplicationResult<User>.Success(user);
+    }
+
+    public async Task<IReadOnlyList<User>> GetAdministratorsAsync()
+    {
+        return (await _userService.GetUsersByRoleAsync(SystemRoleConstants.AdminId))
+            .Where(x => x.Status == UserStatus.Normal)
+            .OrderBy(x => x.Team)
+            .ThenBy(x => x.UserName)
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<User>> GetAllActiveAsync()
+    {
+        return (await _userService.GetAll())
+            .Where(IsVisibleUser)
+            .OrderBy(x => x.Team)
+            .ThenBy(x => x.UserName)
+            .ToList();
+    }
+
+    private DateTime GetLocalNow()
+    {
+        return _timeProvider.GetLocalNow().DateTime;
+    }
+
+    private static bool IsVisibleUser(User user)
+    {
+        return user.Status == UserStatus.Normal && user.Id != SystemSettings.SuperAdminId;
+    }
+
+    private static List<string> NormalizeRoleIds(IReadOnlyList<string> roleIds)
+    {
+        var normalized = roleIds?
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Distinct()
+            .ToList() ?? [];
+        if (normalized.Count == 0) normalized.Add(SystemRoleConstants.OperatorId);
+        return normalized;
+    }
+}

--- a/src/AgileConfig.Server.IService/IRoleService.cs
+++ b/src/AgileConfig.Server.IService/IRoleService.cs
@@ -8,6 +8,7 @@ public interface IRoleService
 {
     Task<List<Role>> GetAllAsync();
     Task<Role> GetAsync(string id);
+    Task<List<string>> GetFunctionsAsync(string roleId);
     Task<Role> CreateAsync(Role role, IEnumerable<string> functions);
     Task<bool> UpdateAsync(Role role, IEnumerable<string> functions);
     Task<bool> DeleteAsync(string id);

--- a/src/AgileConfig.Server.Service/RoleService.cs
+++ b/src/AgileConfig.Server.Service/RoleService.cs
@@ -83,6 +83,12 @@ public class RoleService : IRoleService
         return _roleDefinitionRepository.GetAsync(id);
     }
 
+    public async Task<List<string>> GetFunctionsAsync(string roleId)
+    {
+        var roleFunctions = await _roleFunctionRepository.QueryAsync(x => x.RoleId == roleId);
+        return roleFunctions.Select(x => x.FunctionId).ToList();
+    }
+
     public async Task<bool> UpdateAsync(Role role, IEnumerable<string> functions)
     {
         if (role == null) throw new ArgumentNullException(nameof(role));

--- a/test/AgileConfig.Server.ApplicationTests/RoleManagementServiceTests.cs
+++ b/test/AgileConfig.Server.ApplicationTests/RoleManagementServiceTests.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AgileConfig.Server.Application;
+using AgileConfig.Server.Application.Roles;
+using AgileConfig.Server.Common;
+using AgileConfig.Server.Data.Entity;
+using AgileConfig.Server.IService;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace AgileConfig.Server.ApplicationTests;
+
+[TestClass]
+public sealed class RoleManagementServiceTests
+{
+    [TestMethod]
+    public async Task GetAllAsync_FiltersSuperAdminSortsAndLoadsFunctions()
+    {
+        var roleService = new Mock<IRoleService>();
+        var superAdmin = new Role
+        {
+            Id = SystemRoleConstants.SuperAdminId,
+            Name = "Super Administrator",
+            IsSystem = true
+        };
+        var operatorRole = new Role
+        {
+            Id = SystemRoleConstants.OperatorId,
+            Name = "Operator",
+            IsSystem = true
+        };
+        var adminRole = new Role
+        {
+            Id = SystemRoleConstants.AdminId,
+            Name = "Administrator",
+            IsSystem = true
+        };
+        var zetaRole = new Role { Id = "zeta", Name = "Zeta", IsSystem = false };
+        var alphaRole = new Role { Id = "alpha", Name = "Alpha", IsSystem = false };
+
+        roleService.Setup(x => x.GetAllAsync())
+            .ReturnsAsync(new List<Role> { zetaRole, superAdmin, operatorRole, alphaRole, adminRole });
+        roleService.Setup(x => x.GetFunctionsAsync(adminRole.Id))
+            .ReturnsAsync(new List<string> { Functions.Role_Read });
+        roleService.Setup(x => x.GetFunctionsAsync(operatorRole.Id))
+            .ReturnsAsync(new List<string> { Functions.App_Read, Functions.Config_Read });
+        roleService.Setup(x => x.GetFunctionsAsync(alphaRole.Id))
+            .ReturnsAsync(new List<string>());
+        roleService.Setup(x => x.GetFunctionsAsync(zetaRole.Id))
+            .ReturnsAsync(new List<string> { Functions.Log_Read });
+
+        var result = await CreateService(roleService).GetAllAsync();
+
+        Assert.AreEqual(4, result.Count);
+        Assert.AreSame(adminRole, result[0].Role);
+        Assert.AreSame(operatorRole, result[1].Role);
+        Assert.AreSame(alphaRole, result[2].Role);
+        Assert.AreSame(zetaRole, result[3].Role);
+        CollectionAssert.AreEqual(new[] { Functions.Role_Read }, result[0].Functions.ToArray());
+        CollectionAssert.AreEqual(
+            new[] { Functions.App_Read, Functions.Config_Read },
+            result[1].Functions.ToArray());
+        Assert.IsFalse(result.Any(x => x.Role.Id == SystemRoleConstants.SuperAdminId));
+        roleService.Verify(x => x.GetFunctionsAsync(SystemRoleConstants.SuperAdminId), Times.Never);
+        roleService.Verify(x => x.GetFunctionsAsync(It.IsAny<string>()), Times.Exactly(4));
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_MapsRoleAndNormalizesFunctions()
+    {
+        var roleService = new Mock<IRoleService>();
+        Role createdRole = null;
+        List<string> createdFunctions = null;
+        roleService.Setup(x => x.GetAsync("custom-role"))
+            .ReturnsAsync((Role)null);
+        roleService.Setup(x => x.CreateAsync(It.IsAny<Role>(), It.IsAny<IEnumerable<string>>()))
+            .Callback<Role, IEnumerable<string>>((role, functions) =>
+            {
+                createdRole = role;
+                createdFunctions = functions.ToList();
+            })
+            .ReturnsAsync((Role role, IEnumerable<string> _) => role);
+
+        var result = await CreateService(roleService).CreateAsync(new CreateRoleCommand(
+            "custom-role",
+            "Custom role",
+            null,
+            new[] { Functions.Role_Read, " ", Functions.Role_Read, null, Functions.App_Read }));
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreSame(createdRole, result.Value);
+        Assert.AreEqual("custom-role", createdRole.Id);
+        Assert.AreEqual("Custom role", createdRole.Name);
+        Assert.AreEqual(string.Empty, createdRole.Description);
+        Assert.IsFalse(createdRole.IsSystem);
+        CollectionAssert.AreEqual(
+            new[] { Functions.Role_Read, Functions.App_Read },
+            createdFunctions);
+        roleService.Verify(x => x.CreateAsync(It.IsAny<Role>(), It.IsAny<IEnumerable<string>>()), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_WhenIdentifierExistsReturnsConflictWithoutWriting()
+    {
+        var roleService = new Mock<IRoleService>();
+        roleService.Setup(x => x.GetAsync("existing"))
+            .ReturnsAsync(new Role { Id = "existing" });
+
+        var result = await CreateService(roleService).CreateAsync(new CreateRoleCommand(
+            "existing", "Duplicate", "description", Array.Empty<string>()));
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ApplicationError.Conflict, result.Error);
+        roleService.Verify(x => x.CreateAsync(It.IsAny<Role>(), It.IsAny<IEnumerable<string>>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task UpdateAsync_WhenRoleDoesNotExistReturnsNotFoundWithoutWriting()
+    {
+        var roleService = new Mock<IRoleService>();
+        roleService.Setup(x => x.GetAsync("missing"))
+            .ReturnsAsync((Role)null);
+
+        var result = await CreateService(roleService).UpdateAsync(new UpdateRoleCommand(
+            "missing", "Updated", null, Array.Empty<string>()));
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ApplicationError.NotFound, result.Error);
+        roleService.Verify(x => x.UpdateAsync(It.IsAny<Role>(), It.IsAny<IEnumerable<string>>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task UpdateAsync_WhenRoleIsSuperAdminReturnsForbiddenWithoutWriting()
+    {
+        var roleService = new Mock<IRoleService>();
+        roleService.Setup(x => x.GetAsync(SystemRoleConstants.SuperAdminId))
+            .ReturnsAsync(new Role
+            {
+                Id = SystemRoleConstants.SuperAdminId,
+                Name = "Super Administrator",
+                IsSystem = true
+            });
+
+        var result = await CreateService(roleService).UpdateAsync(new UpdateRoleCommand(
+            SystemRoleConstants.SuperAdminId,
+            "Changed",
+            "Changed description",
+            new[] { Functions.Role_Edit }));
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ApplicationError.Forbidden, result.Error);
+        roleService.Verify(x => x.UpdateAsync(It.IsAny<Role>(), It.IsAny<IEnumerable<string>>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task UpdateAsync_PreservesSystemFlagAndMapsNormalizedFunctions()
+    {
+        var roleService = new Mock<IRoleService>();
+        var existingRole = new Role
+        {
+            Id = "system-role",
+            Name = "Old name",
+            Description = "Old description",
+            IsSystem = true
+        };
+        Role updatedRole = null;
+        List<string> updatedFunctions = null;
+        roleService.Setup(x => x.GetAsync(existingRole.Id)).ReturnsAsync(existingRole);
+        roleService.Setup(x => x.UpdateAsync(It.IsAny<Role>(), It.IsAny<IEnumerable<string>>()))
+            .Callback<Role, IEnumerable<string>>((role, functions) =>
+            {
+                updatedRole = role;
+                updatedFunctions = functions.ToList();
+            })
+            .ReturnsAsync(true);
+
+        var result = await CreateService(roleService).UpdateAsync(new UpdateRoleCommand(
+            existingRole.Id,
+            "New name",
+            null,
+            new[] { Functions.Config_Read, "", Functions.Config_Read }));
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreSame(updatedRole, result.Value);
+        Assert.AreEqual(existingRole.Id, updatedRole.Id);
+        Assert.AreEqual("New name", updatedRole.Name);
+        Assert.AreEqual(string.Empty, updatedRole.Description);
+        Assert.IsTrue(updatedRole.IsSystem);
+        CollectionAssert.AreEqual(new[] { Functions.Config_Read }, updatedFunctions);
+        roleService.Verify(x => x.UpdateAsync(It.IsAny<Role>(), It.IsAny<IEnumerable<string>>()), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task UpdateAsync_WhenPersistenceFailsReturnsOperationFailed()
+    {
+        var roleService = new Mock<IRoleService>();
+        roleService.Setup(x => x.GetAsync("role-1"))
+            .ReturnsAsync(new Role { Id = "role-1", IsSystem = false });
+        roleService.Setup(x => x.UpdateAsync(It.IsAny<Role>(), It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync(false);
+
+        var result = await CreateService(roleService).UpdateAsync(new UpdateRoleCommand(
+            "role-1", "Updated", "description", new[] { Functions.Role_Read }));
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ApplicationError.OperationFailed, result.Error);
+        roleService.Verify(x => x.UpdateAsync(It.IsAny<Role>(), It.IsAny<IEnumerable<string>>()), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_WhenRoleDoesNotExistReturnsNotFoundWithoutDeleting()
+    {
+        var roleService = new Mock<IRoleService>();
+        roleService.Setup(x => x.GetAsync("missing"))
+            .ReturnsAsync((Role)null);
+
+        var result = await CreateService(roleService).DeleteAsync("missing");
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ApplicationError.NotFound, result.Error);
+        roleService.Verify(x => x.DeleteAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_WhenRoleIsSystemReturnsForbiddenWithoutDeleting()
+    {
+        var roleService = new Mock<IRoleService>();
+        roleService.Setup(x => x.GetAsync(SystemRoleConstants.AdminId))
+            .ReturnsAsync(new Role
+            {
+                Id = SystemRoleConstants.AdminId,
+                Name = "Administrator",
+                IsSystem = true
+            });
+
+        var result = await CreateService(roleService).DeleteAsync(SystemRoleConstants.AdminId);
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ApplicationError.Forbidden, result.Error);
+        roleService.Verify(x => x.DeleteAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_WhenRoleIsDeletedReturnsSuccess()
+    {
+        var roleService = new Mock<IRoleService>();
+        roleService.Setup(x => x.GetAsync("role-1"))
+            .ReturnsAsync(new Role { Id = "role-1", IsSystem = false });
+        roleService.Setup(x => x.DeleteAsync("role-1"))
+            .ReturnsAsync(true);
+
+        var result = await CreateService(roleService).DeleteAsync("role-1");
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreEqual(ApplicationError.None, result.Error);
+        roleService.Verify(x => x.DeleteAsync("role-1"), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_WhenPersistenceFailsReturnsOperationFailed()
+    {
+        var roleService = new Mock<IRoleService>();
+        roleService.Setup(x => x.GetAsync("role-1"))
+            .ReturnsAsync(new Role { Id = "role-1", IsSystem = false });
+        roleService.Setup(x => x.DeleteAsync("role-1"))
+            .ReturnsAsync(false);
+
+        var result = await CreateService(roleService).DeleteAsync("role-1");
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ApplicationError.OperationFailed, result.Error);
+        roleService.Verify(x => x.DeleteAsync("role-1"), Times.Once);
+    }
+
+    [TestMethod]
+    public void GetSupportedPermissions_ReturnsCorePermissionKeys()
+    {
+        var permissions = CreateService(new Mock<IRoleService>()).GetSupportedPermissions();
+
+        Assert.IsTrue(permissions.Count > 0);
+        CollectionAssert.Contains(permissions.ToList(), Functions.App_Read);
+        CollectionAssert.Contains(permissions.ToList(), Functions.Config_Publish);
+        CollectionAssert.Contains(permissions.ToList(), Functions.Role_Read);
+        CollectionAssert.Contains(permissions.ToList(), Functions.Log_Read);
+        Assert.AreEqual(permissions.Count, permissions.Distinct().Count());
+    }
+
+    private static RoleManagementService CreateService(Mock<IRoleService> roleService)
+    {
+        return new RoleManagementService(roleService.Object);
+    }
+}

--- a/test/AgileConfig.Server.ApplicationTests/UserManagementServiceTests.cs
+++ b/test/AgileConfig.Server.ApplicationTests/UserManagementServiceTests.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AgileConfig.Server.Application;
+using AgileConfig.Server.Application.Users;
+using AgileConfig.Server.Common;
+using AgileConfig.Server.Common.EventBus;
+using AgileConfig.Server.Data.Entity;
+using AgileConfig.Server.Event;
+using AgileConfig.Server.IService;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace AgileConfig.Server.ApplicationTests;
+
+[TestClass]
+public sealed class UserManagementServiceTests
+{
+    [TestMethod]
+    public async Task SearchAsync_FiltersSortsPagesAndLoadsRolesForCurrentPage()
+    {
+        var userService = new Mock<IUserService>();
+        var now = new DateTime(2026, 1, 1);
+        userService.Setup(x => x.GetAll()).ReturnsAsync(new List<User>
+        {
+            new() { Id = "older", UserName = "alice", Team = "platform", Status = UserStatus.Normal, CreateTime = now.AddDays(-1) },
+            new() { Id = "newer", UserName = "alice-2", Team = "platform", Status = UserStatus.Normal, CreateTime = now },
+            new() { Id = "other", UserName = "bob", Team = "platform", Status = UserStatus.Normal, CreateTime = now.AddDays(1) },
+            new() { Id = "deleted", UserName = "alice", Team = "platform", Status = UserStatus.Deleted, CreateTime = now },
+            new() { Id = SystemSettings.SuperAdminId, UserName = "alice-admin", Team = "platform", Status = UserStatus.Normal, CreateTime = now }
+        });
+        userService.Setup(x => x.GetUserRolesAsync("older"))
+            .ReturnsAsync(new List<Role> { new() { Id = "operator", Name = "Operator" } });
+
+        var result = await CreateService(userService).SearchAsync(
+            new SearchUsersQuery("alice", "platform", 2, 1));
+
+        Assert.AreEqual(2, result.Total);
+        Assert.AreEqual(2, result.Current);
+        Assert.AreEqual(1, result.PageSize);
+        Assert.AreEqual("older", result.Users.Single().User.Id);
+        CollectionAssert.AreEqual(new[] { "operator" }, result.Users.Single().RoleIds.ToArray());
+        userService.Verify(x => x.GetUserRolesAsync("older"), Times.Once);
+        userService.Verify(x => x.GetUserRolesAsync(It.Is<string>(id => id != "older")), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_WhenActiveUserExists_ReturnsConflictWithoutWriting()
+    {
+        var userService = new Mock<IUserService>();
+        userService.Setup(x => x.GetUsersByNameAsync("alice"))
+            .ReturnsAsync(new List<User> { new() { UserName = "alice", Status = UserStatus.Normal } });
+
+        var result = await CreateService(userService).CreateAsync(
+            new CreateUserCommand("alice", "secret", "team", Array.Empty<string>()));
+
+        Assert.AreEqual(ApplicationError.Conflict, result.Error);
+        userService.Verify(x => x.AddAsync(It.IsAny<User>()), Times.Never);
+        userService.Verify(x => x.UpdateUserRolesAsync(It.IsAny<string>(), It.IsAny<List<string>>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_MapsPasswordTimeRolesAndEvent()
+    {
+        var userService = new Mock<IUserService>();
+        var eventBus = new Mock<ITinyEventBus>();
+        var time = new FixedTimeProvider(new DateTimeOffset(2026, 2, 3, 4, 5, 6, TimeSpan.Zero));
+        User created = null;
+        List<string> roles = null;
+        userService.Setup(x => x.GetUsersByNameAsync("alice")).ReturnsAsync(new List<User>());
+        userService.Setup(x => x.AddAsync(It.IsAny<User>()))
+            .Callback<User>(x => created = x)
+            .ReturnsAsync(true);
+        userService.Setup(x => x.UpdateUserRolesAsync(It.IsAny<string>(), It.IsAny<List<string>>()))
+            .Callback<string, List<string>>((_, value) => roles = value)
+            .ReturnsAsync(true);
+
+        var result = await CreateService(userService, eventBus, time).CreateAsync(
+            new CreateUserCommand("alice", "secret", "platform", new[] { "role-1", "", "role-1" }));
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreSame(created, result.Value);
+        Assert.AreEqual("alice", created.UserName);
+        Assert.AreEqual("platform", created.Team);
+        Assert.AreEqual(time.GetLocalNow().DateTime, created.CreateTime);
+        Assert.AreEqual(Encrypt.Md5("secret" + created.Salt), created.Password);
+        CollectionAssert.AreEqual(new[] { "role-1" }, roles);
+        eventBus.Verify(x => x.Fire(It.Is<AddUserSuccessful>(e =>
+            ReferenceEquals(e.User, created) && e.UserName == "operator")), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_UsesOperatorRoleByDefaultAndReportsPartialFailure()
+    {
+        var userService = new Mock<IUserService>();
+        userService.Setup(x => x.GetUsersByNameAsync(It.IsAny<string>())).ReturnsAsync(new List<User>());
+        userService.Setup(x => x.AddAsync(It.IsAny<User>())).ReturnsAsync(true);
+        userService.Setup(x => x.UpdateUserRolesAsync(It.IsAny<string>(), It.IsAny<List<string>>()))
+            .ReturnsAsync(false);
+
+        var result = await CreateService(userService).CreateAsync(
+            new CreateUserCommand("alice", "secret", null, null));
+
+        Assert.AreEqual(ApplicationError.OperationFailed, result.Error);
+        userService.Verify(x => x.UpdateUserRolesAsync(result.Value.Id,
+            It.Is<List<string>>(roles => roles.SequenceEqual(new[] { SystemRoleConstants.OperatorId }))), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task UpdateAsync_WhenMissing_ReturnsNotFoundWithoutWriting()
+    {
+        var userService = new Mock<IUserService>();
+        userService.Setup(x => x.GetUserAsync("missing")).ReturnsAsync((User)null);
+
+        var result = await CreateService(userService).UpdateAsync(
+            new UpdateUserCommand("missing", "team", Array.Empty<string>()));
+
+        Assert.AreEqual(ApplicationError.NotFound, result.Error);
+        userService.Verify(x => x.UpdateAsync(It.IsAny<User>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task UpdateAsync_UpdatesTeamRolesTimeAndEvent()
+    {
+        var userService = new Mock<IUserService>();
+        var eventBus = new Mock<ITinyEventBus>();
+        var time = new FixedTimeProvider(new DateTimeOffset(2026, 3, 4, 5, 6, 7, TimeSpan.Zero));
+        var user = new User { Id = "user-1", UserName = "alice", Team = "old" };
+        userService.Setup(x => x.GetUserAsync(user.Id)).ReturnsAsync(user);
+        userService.Setup(x => x.UpdateAsync(user)).ReturnsAsync(true);
+        userService.Setup(x => x.UpdateUserRolesAsync(user.Id, It.IsAny<List<string>>())).ReturnsAsync(true);
+
+        var result = await CreateService(userService, eventBus, time).UpdateAsync(
+            new UpdateUserCommand(user.Id, "new", new[] { "role-1", "role-1" }));
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreEqual("new", user.Team);
+        Assert.AreEqual(time.GetLocalNow().DateTime, user.UpdateTime);
+        userService.Verify(x => x.UpdateUserRolesAsync(user.Id,
+            It.Is<List<string>>(roles => roles.SequenceEqual(new[] { "role-1" }))), Times.Once);
+        eventBus.Verify(x => x.Fire(It.Is<EditUserSuccessful>(e =>
+            ReferenceEquals(e.User, user) && e.UserName == "operator")), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task ResetPasswordAsync_HandlesMissingFailureAndSuccess()
+    {
+        var userService = new Mock<IUserService>();
+        var eventBus = new Mock<ITinyEventBus>();
+        var user = new User { Id = "user-1", UserName = "alice", Salt = "salt" };
+        userService.Setup(x => x.GetUserAsync("missing")).ReturnsAsync((User)null);
+        userService.Setup(x => x.GetUserAsync(user.Id)).ReturnsAsync(user);
+        userService.SetupSequence(x => x.UpdateAsync(user)).ReturnsAsync(false).ReturnsAsync(true);
+        var service = CreateService(userService, eventBus);
+
+        Assert.AreEqual(ApplicationError.NotFound, (await service.ResetPasswordAsync("missing")).Error);
+        Assert.AreEqual(ApplicationError.OperationFailed, (await service.ResetPasswordAsync(user.Id)).Error);
+        Assert.AreEqual(Encrypt.Md5("123456" + user.Salt), user.Password);
+        Assert.IsTrue((await service.ResetPasswordAsync(user.Id)).Succeeded);
+        eventBus.Verify(x => x.Fire(It.Is<ResetUserPasswordSuccessful>(e =>
+            e.OpUser == "operator" && e.UserName == "alice")), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_HandlesMissingFailureAndSuccess()
+    {
+        var userService = new Mock<IUserService>();
+        var eventBus = new Mock<ITinyEventBus>();
+        var user = new User { Id = "user-1", UserName = "alice", Status = UserStatus.Normal };
+        userService.Setup(x => x.GetUserAsync("missing")).ReturnsAsync((User)null);
+        userService.Setup(x => x.GetUserAsync(user.Id)).ReturnsAsync(user);
+        userService.SetupSequence(x => x.UpdateAsync(user)).ReturnsAsync(false).ReturnsAsync(true);
+        var service = CreateService(userService, eventBus);
+
+        Assert.AreEqual(ApplicationError.NotFound, (await service.DeleteAsync("missing")).Error);
+        Assert.AreEqual(ApplicationError.OperationFailed, (await service.DeleteAsync(user.Id)).Error);
+        Assert.AreEqual(UserStatus.Deleted, user.Status);
+        Assert.IsTrue((await service.DeleteAsync(user.Id)).Succeeded);
+        eventBus.Verify(x => x.Fire(It.Is<DeleteUserSuccessful>(e =>
+            ReferenceEquals(e.User, user) && e.UserName == "operator")), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task DirectoryQueries_FilterAndSortUsers()
+    {
+        var userService = new Mock<IUserService>();
+        var activeUsers = new List<User>
+        {
+            new() { Id = "z", UserName = "z", Team = "z", Status = UserStatus.Normal },
+            new() { Id = "a2", UserName = "z", Team = "a", Status = UserStatus.Normal },
+            new() { Id = "a1", UserName = "a", Team = "a", Status = UserStatus.Normal },
+            new() { Id = "deleted", UserName = "d", Team = "a", Status = UserStatus.Deleted },
+            new() { Id = SystemSettings.SuperAdminId, UserName = "admin", Team = "a", Status = UserStatus.Normal }
+        };
+        userService.Setup(x => x.GetAll()).ReturnsAsync(activeUsers);
+        userService.Setup(x => x.GetUsersByRoleAsync(SystemRoleConstants.AdminId)).ReturnsAsync(activeUsers);
+        var service = CreateService(userService);
+
+        var all = await service.GetAllActiveAsync();
+        var administrators = await service.GetAdministratorsAsync();
+
+        Assert.AreEqual("a1,a2,z", string.Join(",", all.Select(x => x.Id)));
+        Assert.AreEqual(
+            $"a1,{SystemSettings.SuperAdminId},a2,z",
+            string.Join(",", administrators.Select(x => x.Id)));
+    }
+
+    private static UserManagementService CreateService(
+        Mock<IUserService> userService,
+        Mock<ITinyEventBus> eventBus = null,
+        TimeProvider timeProvider = null)
+    {
+        var currentUser = new Mock<ICurrentUserAccessor>();
+        currentUser.SetupGet(x => x.UserName).Returns("operator");
+        return new UserManagementService(
+            userService.Object,
+            (eventBus ?? new Mock<ITinyEventBus>()).Object,
+            currentUser.Object,
+            timeProvider ?? TimeProvider.System);
+    }
+
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _utcNow;
+
+        public FixedTimeProvider(DateTimeOffset utcNow)
+        {
+            _utcNow = utcNow;
+        }
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            return _utcNow;
+        }
+    }
+}

--- a/test/ApiSiteTests/ControllerDependencyArchitectureTests.cs
+++ b/test/ApiSiteTests/ControllerDependencyArchitectureTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using AgileConfig.Server.Apisite;
+using AgileConfig.Server.Apisite.Controllers;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -45,5 +46,22 @@ public sealed class ControllerDependencyArchitectureTests
 
         Assert.IsEmpty(invalidDependencies,
             $"V2 controllers must access use cases through the Application layer: {string.Join(", ", invalidDependencies)}");
+    }
+
+    [TestMethod]
+    public void MigratedIdentityControllers_UseOnlyApplicationServices()
+    {
+        var migratedControllers = new[] { typeof(UserController), typeof(RoleController) };
+        var invalidDependencies = migratedControllers
+            .SelectMany(type => type.GetConstructors()
+                .SelectMany(constructor => constructor.GetParameters()
+                    .Where(parameter => parameter.ParameterType.Namespace == null ||
+                                        !parameter.ParameterType.Namespace.StartsWith(
+                                            "AgileConfig.Server.Application"))
+                    .Select(parameter => $"{type.FullName} -> {parameter.ParameterType.FullName}")))
+            .ToList();
+
+        Assert.IsEmpty(invalidDependencies,
+            $"Migrated identity controllers must use Application services: {string.Join(", ", invalidDependencies)}");
     }
 }

--- a/test/ApiSiteTests/RoleControllerTests.cs
+++ b/test/ApiSiteTests/RoleControllerTests.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AgileConfig.Server.Application;
+using AgileConfig.Server.Application.Roles;
+using AgileConfig.Server.Apisite.Controllers;
+using AgileConfig.Server.Apisite.Models;
+using AgileConfig.Server.Common;
+using AgileConfig.Server.Common.Resources;
+using AgileConfig.Server.Data.Entity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace ApiSiteTests;
+
+[TestClass]
+public sealed class RoleControllerTests
+{
+    [TestMethod]
+    public async Task ListAndSupportedPermissions_MapApplicationResultsToLegacyEnvelope()
+    {
+        var service = new Mock<IRoleManagementService>();
+        var role = new Role { Id = "role-1", Name = "Role 1", Description = "Description", IsSystem = true };
+        service.Setup(x => x.GetAllAsync()).ReturnsAsync(new List<RoleDetails>
+        {
+            new(role, new[] { "permission-1" })
+        });
+        service.Setup(x => x.GetSupportedPermissions()).Returns(new[] { "permission-1", "permission-2" });
+        var controller = new RoleController(service.Object);
+
+        var listResult = AsJson(await controller.List());
+        var roles = Read<IEnumerable<RoleVM>>(listResult, "data").ToList();
+        var permissionsResult = AsJson(controller.SupportedPermissions());
+
+        Assert.IsTrue(Read<bool>(listResult, "success"));
+        Assert.AreEqual("role-1", roles.Single().Id);
+        Assert.IsTrue(roles.Single().IsSystem);
+        CollectionAssert.AreEqual(new[] { "permission-1" }, roles.Single().Functions);
+        CollectionAssert.AreEqual(
+            new[] { "permission-1", "permission-2" },
+            Read<IReadOnlyList<string>>(permissionsResult, "data").ToArray());
+    }
+
+    [TestMethod]
+    public async Task Add_MapsCommandAndApplicationResult()
+    {
+        var service = new Mock<IRoleManagementService>();
+        CreateRoleCommand captured = null;
+        service.Setup(x => x.CreateAsync(It.IsAny<CreateRoleCommand>()))
+            .Callback<CreateRoleCommand>(command => captured = command)
+            .ReturnsAsync(ApplicationResult<Role>.Success(new Role { Id = "role-1" }));
+        var controller = new RoleController(service.Object);
+        var model = new RoleVM
+        {
+            Id = "role-1",
+            Name = "Role 1",
+            Description = "Description",
+            Functions = new List<string> { "permission-1" }
+        };
+
+        Assert.ThrowsExactly<ArgumentNullException>(() => controller.Add(null).GetAwaiter().GetResult());
+        var result = AsJson(await controller.Add(model));
+
+        Assert.IsTrue(Read<bool>(result, "success"));
+        Assert.AreEqual(model.Id, captured.Id);
+        Assert.AreEqual(model.Name, captured.Name);
+        Assert.AreEqual(model.Description, captured.Description);
+        CollectionAssert.AreEqual(model.Functions, captured.Functions.ToList());
+    }
+
+    [TestMethod]
+    public async Task Edit_MapsForbiddenAndOperationFailure()
+    {
+        var service = new Mock<IRoleManagementService>();
+        service.Setup(x => x.UpdateAsync(It.Is<UpdateRoleCommand>(command =>
+                command.Id == SystemRoleConstants.SuperAdminId)))
+            .ReturnsAsync(ApplicationResult<Role>.Failure(ApplicationError.Forbidden));
+        service.Setup(x => x.UpdateAsync(It.Is<UpdateRoleCommand>(command => command.Id == "role-1")))
+            .ReturnsAsync(ApplicationResult<Role>.Failure(ApplicationError.OperationFailed));
+        var controller = new RoleController(service.Object);
+
+        Assert.ThrowsExactly<ArgumentNullException>(() => controller.Edit(null).GetAwaiter().GetResult());
+        var forbidden = AsJson(await controller.Edit(new RoleVM
+        {
+            Id = SystemRoleConstants.SuperAdminId,
+            Name = "Super Administrator"
+        }));
+        var failed = AsJson(await controller.Edit(new RoleVM { Id = "role-1", Name = "Role 1" }));
+
+        Assert.IsFalse(Read<bool>(forbidden, "success"));
+        StringAssert.Contains(Read<string>(forbidden, "message"), "cannot be edited");
+        Assert.IsFalse(Read<bool>(failed, "success"));
+        Assert.AreEqual(Messages.UpdateRoleFailed, Read<string>(failed, "message"));
+    }
+
+    [TestMethod]
+    public async Task Delete_MapsForbiddenFailureAndSuccess()
+    {
+        var service = new Mock<IRoleManagementService>();
+        service.Setup(x => x.DeleteAsync(SystemRoleConstants.SuperAdminId))
+            .ReturnsAsync(ApplicationResult.Failure(ApplicationError.Forbidden));
+        service.Setup(x => x.DeleteAsync("failed"))
+            .ReturnsAsync(ApplicationResult.Failure(ApplicationError.OperationFailed));
+        service.Setup(x => x.DeleteAsync("deleted"))
+            .ReturnsAsync(ApplicationResult.Success());
+        var controller = new RoleController(service.Object);
+
+        Assert.ThrowsExactly<ArgumentNullException>(() => controller.Delete(null).GetAwaiter().GetResult());
+        var forbidden = AsJson(await controller.Delete(SystemRoleConstants.SuperAdminId));
+        var failed = AsJson(await controller.Delete("failed"));
+        var deleted = AsJson(await controller.Delete("deleted"));
+
+        StringAssert.Contains(Read<string>(forbidden, "message"), "cannot be deleted");
+        Assert.AreEqual(Messages.DeleteRoleFailed, Read<string>(failed, "message"));
+        Assert.IsTrue(Read<bool>(deleted, "success"));
+        Assert.AreEqual(string.Empty, Read<string>(deleted, "message"));
+    }
+
+    private static JsonResult AsJson(IActionResult result)
+    {
+        Assert.IsInstanceOfType<JsonResult>(result);
+        return (JsonResult)result;
+    }
+
+    private static T Read<T>(JsonResult result, string propertyName)
+    {
+        var property = result.Value?.GetType().GetProperty(propertyName);
+        Assert.IsNotNull(property);
+        return (T)property.GetValue(result.Value);
+    }
+}

--- a/test/ApiSiteTests/UserControllerCoverageTests.cs
+++ b/test/ApiSiteTests/UserControllerCoverageTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using AgileConfig.Server.Application;
+using AgileConfig.Server.Application.Users;
 using AgileConfig.Server.Apisite.Controllers;
 using AgileConfig.Server.Apisite.Models;
 using AgileConfig.Server.Common;
@@ -327,7 +329,14 @@ public sealed class UserControllerCoverageTests
             User = new ClaimsPrincipal(new ClaimsIdentity(
                 new[] { new Claim("username", currentUser) }, "test"))
         };
-        var controller = new UserController(userService.Object, eventBus.Object);
+        var currentUserAccessor = new Mock<ICurrentUserAccessor>();
+        currentUserAccessor.SetupGet(x => x.UserName).Returns(currentUser);
+        var managementService = new UserManagementService(
+            userService.Object,
+            eventBus.Object,
+            currentUserAccessor.Object,
+            TimeProvider.System);
+        var controller = new UserController(managementService);
         controller.ControllerContext = new ControllerContext { HttpContext = context };
         return controller;
     }


### PR DESCRIPTION
## Summary

- add transport-independent user and role management application services
- convert legacy user and role controllers to thin HTTP adapters
- move role permission lookup behind IRoleService and protect system-role state
- add application, controller compatibility, and dependency-boundary tests

## Testing

- dotnet test test/AgileConfig.Server.ApplicationTests/AgileConfig.Server.ApplicationTests.csproj --no-restore -m:1 -p:WarningsNotAsErrors=NU1510
- dotnet test test/ApiSiteTests/ApiSiteTests.csproj --no-restore -m:1 -p:WarningsNotAsErrors=NU1510
- dotnet build AgileConfig.sln --no-restore -m:1 -p:WarningsNotAsErrors=NU1510